### PR TITLE
Fix password update form

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -41,7 +41,7 @@ function DisplayAuthConfig($username, $password){
 				<div class="panel-heading"><i class="fa fa-lock fa-fw"></i>Configure Auth</div>
 				<div class="panel-body">
 					<p><?php echo $status; ?></p>
-					<form role="form" action="/?page=admin_conf" method="POST">
+					<form role="form" action="/?page=auth_conf" method="POST">
 						<div class="row">
 							<div class="form-group col-md-4">
 								<label for="username">Username</label>


### PR DESCRIPTION
The page name for the admin page had been changed to auth_conf but the form had not been changed accordingly.