### PR TITLE
Fix default setup

### DIFF
--- a/config/hostapd.conf
+++ b/config/hostapd.conf
@@ -9,6 +9,6 @@ channel=1
 hw_mode=g
 wpa_passphrase=ChangeMe
 interface=wlan0
-wpa=WPA2
+wpa=1
 wpa_pairwise=TKIP
 country_code=

--- a/config/rc.local
+++ b/config/rc.local
@@ -1,0 +1,24 @@
+#!/bin/sh -e
+#
+# rc.local
+#
+# This script is executed at the end of each multiuser runlevel.
+# Make sure that the script will "exit 0" on success or any other
+# value on error.
+#
+# In order to enable or disable this script just change the execution
+# bits.
+#
+# By default this script does nothing.
+
+# Print the IP address
+_IP=$(hostname -I) || true
+if [ "$_IP" ]; then
+  printf "My IP address is %s\n" "$_IP"
+fi
+
+# Set up IP forwarding and NAT routing
+echo 1 > /proc/sys/net/ipv4/ip_forward
+iptables -t nat -A POSTROUTING -j MASQUERADE
+
+exit 0

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -114,6 +114,7 @@ function default_configuration() {
     sudo mv $webroot_dir/config/hostapd.conf /etc/hostapd/hostapd.conf || install_error "Unable to move hostapd configuration file"
     sudo mv $webroot_dir/config/dnsmasq.conf /etc/dnsmasq.conf || install_error "Unable to move dnsmasq configuration file"
     sudo mv $webroot_dir/config/dhcpcd.conf /etc/dhcpcd.conf || install_error "Unable to move dhcpcd configuration file"
+    sudo mv $webroot_dir/config/rc.local /etc/rc.local || install_error "Unable to move rc.local file"
 }
 
 # Add a single entry to the sudoers file


### PR DESCRIPTION
* The setup script doesn't currently set up NAT routing. The `rc.local` file now does this.
* The default `hostapd.conf` has an incorrect setting for `wpa` which effectively creates an open network.