### PR TITLE
Various small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The installer will complete the steps in the manual installation (below) for you
 After the reboot at the end of the installation the wireless network will be
 configured as an access point as follows:
 * IP address: 10.3.141.1
+  * Username: admin
+  * Password: secret
 * DHCP range: 10.3.141.50 to 10.3.141.255
 * SSID: `raspi-webgui`
 * Password: ChangeMe

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -1,13 +1,13 @@
 raspap_dir="/etc/raspap"
 raspap_user="www-data"
-version=`cat /etc/debian_version`
+version=`sed 's/\..*//' /etc/debian_version`
 
 # Determine version and set default home location for lighttpd 
-if [ $version == "8.0" ]; then
-    echo "Raspian verison is 8.0 Jessie"
+if [ $version -ge 8 ]; then
+    echo "Raspian verison is 8.0 or later"
     webroot_dir="/var/www/html"
-elif [ $version == "7.8" ]; then
-    echo "Raspian version is 7.8 Wheezy"
+elif; then
+    echo "Raspian version is earlier than 8.0"
     webroot_dir="/var/www"
 fi
 
@@ -27,11 +27,13 @@ function install_error() {
 
 function config_installation() {
     install_log "Configure installation"
-    echo -n "Install directory [${raspap_dir}]: "
-    read input
-    if [ ! -z "$input" ]; then
-        raspap_dir="$input"
-    fi
+    # This causes confusion. For the moment fix the default.
+    #echo -n "Install directory [${raspap_dir}]: "
+    #read input
+    #if [ ! -z "$input" ]; then
+    #    raspap_dir="$input"
+    #fi
+    echo "Install directory: ${raspap_dir}"
 
     echo -n "Complete installation with these values? [y/N]: "
     read answer
@@ -75,7 +77,7 @@ function create_raspap_directories() {
 # Fetches latest files from github to webroot
 function download_latest_files() {
     if [ -d "$webroot_dir" ]; then
-        sudo mv $webroot_dir /tmp/old_webroot || install_error "Unable to remove old webroot directory"
+        sudo mv $webroot_dir $webroot.old || install_error "Unable to remove old webroot directory"
     fi
 
     install_log "Cloning latest files from github"

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -6,7 +6,7 @@ version=`sed 's/\..*//' /etc/debian_version`
 if [ $version -ge 8 ]; then
     echo "Raspian verison is 8.0 or later"
     webroot_dir="/var/www/html"
-elif; then
+else
     echo "Raspian version is earlier than 8.0"
     webroot_dir="/var/www"
 fi


### PR DESCRIPTION
* Append `.old` to old web directory instead of moving to `/tmp`
* Do not give the user a choice of install location
* Better detection of Debian version
* List username and password in Quick Start instructions