### PR TITLE
FIX - wlan0 status doesn't contain RUNNING only UP

### DIFF
--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -44,7 +44,7 @@ function DisplayDashboard(){
   preg_match('/Frequency:(\d+.\d+ GHz)/i',$strWlan0,$result);
   $strFrequency = $result[1];
 
-  if(strpos( $strWlan0, "UP" ) !== false && strpos( $strWlan0, "RUNNING" ) !== false ) {
+  if(strpos( $strWlan0, "UP" ) !== false) { // && strpos( $strWlan0, "RUNNING" ) !== false ) {
     $status->addMessage('Interface is up', 'success');
     $wlan0up = true;
   } else {


### PR DESCRIPTION
Tested on RPi3 Raspbian Jessie

Maybe this could be helpful because it was blocking me from being able to configure the wifi client on a freshly installed pi