### PR TITLE
Updating dashboard to use ip rather than ifdown/up

### DIFF
--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -54,14 +54,14 @@ function DisplayDashboard(){
   if( isset($_POST['ifdown_wlan0']) ) {
     exec( 'ifconfig wlan0 | grep -i running | wc -l',$test );
     if($test[0] == 1) {
-      exec( 'sudo ifdown wlan0',$return );
+      exec( 'sudo ip link set wlan0 down',$return );
     } else {
       echo 'Interface already down';
     }
   } elseif( isset($_POST['ifup_wlan0']) ) {
     exec( 'ifconfig wlan0 | grep -i running | wc -l',$test );
     if($test[0] == 0) {
-      exec( 'sudo ifup wlan0',$return );
+      exec( 'sudo ip link set wlan0 up',$return );
     } else {
       echo 'Interface already up';
     }
@@ -134,7 +134,7 @@ function DisplayDashboard(){
             </div><!-- /.panel-default -->
         </div><!-- /.col-lg-12 -->
     </div><!-- /.row -->
-  <?php 
+  <?php
 }
 
 ?>


### PR DESCRIPTION
using ifdown/ifup requires /etc/network/interfaces to be configured correctly.
In the case of it not being configured, ifdown and ifup won't work.
Using ip link rather than ifdown/ifup will resolve this issue