### PR TITLE
Migrating from ifconfig to ip

### DIFF
--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -27,7 +27,6 @@ function DisplayDashboard(){
   foreach($result[1] as $netmask) {
     $strNetMask .= long2ip(-1 << (32 -(int)$netmask))." ";
   }
-  //$strNetMask = long2ip(-1 << (32 - (int)$result[1][0]));
   preg_match( '/RX packets:(\d+)/',$strWlan0,$result ) || $result[1] = 'No Data';
   $strRxPackets = $result[1];
   preg_match( '/TX packets:(\d+)/',$strWlan0,$result ) || $result[1] = 'No Data';

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -14,8 +14,6 @@ function DisplayDashboard(){
   $strWlan0 = implode( " ", $return );
   $strWlan0 = preg_replace( '/\s\s+/', ' ', $strWlan0 );
 
-  var_dump($strWlan0);
-
   // Parse results from ifconfig/iwconfig
   preg_match( '/link\/ether ([0-9a-f:]+)/i',$strWlan0,$result ) || $result[1] = 'No MAC Address Found';
   $strHWAddress = $result[1];


### PR DESCRIPTION
Stretch users won't see IP Address, MAC address, or subnet mask as the output of ifconfig has changed.
There was also no provision to show multiple IP addresses on wlan0 if wlan0 had more than 1 ip address, which has now been fixed. Output could possibly be cleaned up a bit more later on.
