### PR TITLE
Fix fastcgi-php setup for fresh install

### DIFF
--- a/installers/common.sh
+++ b/installers/common.sh
@@ -73,7 +73,13 @@ function enable_php_lighttpd() {
     install_log "Enabling PHP for lighttpd"
 
     sudo lighty-enable-mod fastcgi-php
-    if [ $? -eq 2 ]; then echo already enabled; else install_error "Cannot enable fastcgi-php for lighttpd"; fi
+    if [ $? -eq 2 ]
+    then
+        echo '  [already enabled]'
+    elif [ $? -ne 0 ]
+    then
+        install_error "Cannot enable fastcgi-php for lighttpd"
+    fi
     sudo /etc/init.d/lighttpd restart || install_error "Unable to restart lighttpd"
 }
 


### PR DESCRIPTION
When the installer was fixed for updates the setup for fastcgi was broken for fresh installs. This should fix it for both.