### PR TITLE
Select wireless interface for wifi client

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -3,7 +3,7 @@
 define('RASPI_CONFIG', '/etc/raspap');
 define('RASPI_CONFIG_NETWORKING',RASPI_CONFIG.'/networking');
 define('RASPI_ADMIN_DETAILS', RASPI_CONFIG.'/raspap.auth');
-define('RASPI_WIFI_CLIENT_INTERFACE', 'wifiKey');
+define('RASPI_WIFI_CLIENT_INTERFACE', 'wlan0');
 
 // Constants for configuration file paths.
 // These are typical for default RPi installs. Modify if needed.
@@ -18,12 +18,12 @@ define('RASPI_OPENVPN_SERVER_CONFIG', '/etc/openvpn/server.conf');
 define('RASPI_TORPROXY_CONFIG', '/etc/tor/torrc');
 
 // Optional services, set to true to enable.
-define('RASPI_HOTSPOT_ENABLED', false );
-define('RASPI_NETWORK_ENABLED', false );
-define('RASPI_DHCP_ENABLED', false );
+define('RASPI_HOTSPOT_ENABLED', true );
+define('RASPI_NETWORK_ENABLED', true );
+define('RASPI_DHCP_ENABLED', true );
 define('RASPI_OPENVPN_ENABLED', false );
 define('RASPI_TORPROXY_ENABLED', false );
-define('RASPI_CONFAUTH_ENABLED', false );
-define('RASPI_CHANGETHEME_ENABLED', false );
+define('RASPI_CONFAUTH_ENABLED', true );
+define('RASPI_CHANGETHEME_ENABLED', true );
 
 ?>

--- a/includes/config.php
+++ b/includes/config.php
@@ -18,7 +18,12 @@ define('RASPI_OPENVPN_SERVER_CONFIG', '/etc/openvpn/server.conf');
 define('RASPI_TORPROXY_CONFIG', '/etc/tor/torrc');
 
 // Optional services, set to true to enable.
+define('RASPI_HOTSPOT_ENABLED', false );
+define('RASPI_NETWORK_ENABLED', false );
+define('RASPI_DHCP_ENABLED', false );
 define('RASPI_OPENVPN_ENABLED', false );
 define('RASPI_TORPROXY_ENABLED', false );
+define('RASPI_CONFAUTH_ENABLED', false );
+define('RASPI_CHANGETHEME_ENABLED', false );
 
 ?>

--- a/includes/config.php
+++ b/includes/config.php
@@ -3,6 +3,7 @@
 define('RASPI_CONFIG', '/etc/raspap');
 define('RASPI_CONFIG_NETWORKING',RASPI_CONFIG.'/networking');
 define('RASPI_ADMIN_DETAILS', RASPI_CONFIG.'/raspap.auth');
+define('RASPI_WIFI_CLIENT_INTERFACE', 'wifiKey');
 
 // Constants for configuration file paths.
 // These are typical for default RPi installs. Modify if needed.

--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -134,7 +134,7 @@ function DisplayWPAConfig(){
     }
   }
 
-  exec( 'iwconfig wlan0', $iwconfig_return );
+  exec( 'iwconfig ' . RASPI_WIFI_CLIENT_INTERFACE, $iwconfig_return );
   foreach ($iwconfig_return as $line) {
     if (preg_match( '/ESSID:\"([^"]+)\"/i',$line,$iwconfig_ssid )) {
       $networks[$iwconfig_ssid[1]]['connected'] = true;
@@ -149,7 +149,7 @@ function DisplayWPAConfig(){
         <!-- /.panel-heading -->
         <div class="panel-body">
           <p><?php $status->showMessages(); ?></p>
-          <h4>Client settings</h4>
+          <h4>Client settings for interface <?php echo RASPI_WIFI_CLIENT_INTERFACE ?></h4>
 	<div class="btn-group btn-block">
 	<a href=".?<?php echo $_SERVER['QUERY_STRING']; ?>" style="padding:10px;float: right;display: block;position: relative;margin-top: -55px;" class="col-md-2 btn btn-info" id="update">Rescan</a>
 	</div>

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -8,8 +8,8 @@ function DisplayDashboard(){
 
   $status = new StatusMessages();
 
-  exec( 'ip a s wlan0', $return );
-  exec( 'iwconfig wlan0', $return );
+  exec( 'ip a s ' . RASPI_WIFI_CLIENT_INTERFACE , $return );
+  exec( 'iwconfig ' . RASPI_WIFI_CLIENT_INTERFACE, $return );
 
   $strWlan0 = implode( " ", $return );
   $strWlan0 = preg_replace( '/\s\s+/', ' ', $strWlan0 );
@@ -58,17 +58,17 @@ function DisplayDashboard(){
   }
 
   if( isset($_POST['ifdown_wlan0']) ) {
-    exec( 'ifconfig wlan0 | grep -i running | wc -l',$test );
+    exec( 'ifconfig ' . RASPI_WIFI_CLIENT_INTERFACE . ' | grep -i running | wc -l',$test );
     if($test[0] == 1) {
-      exec( 'sudo ip link set wlan0 down',$return );
+      exec( 'sudo ip link set ' . RASPI_WIFI_CLIENT_INTERFACE . ' down',$return );
     } else {
       echo 'Interface already down';
     }
   } elseif( isset($_POST['ifup_wlan0']) ) {
-    exec( 'ifconfig wlan0 | grep -i running | wc -l',$test );
+    exec( 'ifconfig ' . RASPI_WIFI_CLIENT_INTERFACE . ' | grep -i running | wc -l',$test );
     if($test[0] == 0) {
-      exec( 'sudo ip link set wlan0 up',$return );
-      exec( 'sudo ip -s a f label wlan0',$return);
+      exec( 'sudo ip link set ' . RASPI_WIFI_CLIENT_INTERFACE . ' up',$return );
+      exec( 'sudo ip -s a f label ' . RASPI_WIFI_CLIENT_INTERFACE,$return);
     } else {
       echo 'Interface already up';
     }
@@ -85,7 +85,7 @@ function DisplayDashboard(){
                         <div class="panel panel-default">
                   <div class="panel-body">
                       <h4>Interface Information</h4>
-          <div class="info-item">Interface Name</div> wlan0</br>
+		      <div class="info-item">Interface Name</div> <?php echo RASPI_WIFI_CLIENT_INTERFACE ?></br>
           <div class="info-item">IP Address</div>     <?php echo $strIPAddress ?></br>
           <div class="info-item">Subnet Mask</div>    <?php echo $strNetMask ?></br>
           <div class="info-item">Mac Address</div>    <?php echo $strHWAddress ?></br></br>
@@ -126,9 +126,9 @@ function DisplayDashboard(){
                  <div class="row">
                     <form action="?page=wlan0_info" method="POST">
                     <?php if ( !$wlan0up ) {
-                      echo '<input type="submit" class="btn btn-success" value="Start wlan0" name="ifup_wlan0" />';
+                      echo '<input type="submit" class="btn btn-success" value="Start ' . RASPI_WIFI_CLIENT_INTERFACE . '" name="ifup_wlan0" />';
                     } else {
-                echo '<input type="submit" class="btn btn-warning" value="Stop wlan0" name="ifdown_wlan0" />';
+                echo '<input type="submit" class="btn btn-warning" value="Stop ' . RASPI_WIFI_CLIENT_INTERFACE . '" name="ifdown_wlan0" />';
               }
               ?>
               <input type="button" class="btn btn-outline btn-primary" value="Refresh" onclick="document.location.reload(true)" />

--- a/includes/system.php
+++ b/includes/system.php
@@ -66,7 +66,7 @@ function DisplaySystem(){
 
   // mem used
   $memused_status = "primary";
-  exec("free -m | awk '/Mem:/ { total=$2 } /buffers\/cache/ { used=$3 } END { print used/total*100}'", $memarray);
+  exec("free -m | awk '/Mem:/ { total=$2 ; used=$3 } END { print used/total*100}'", $memarray);
   $memused = floor($memarray[0]);
   if     ($memused > 90) { $memused_status = "danger";  }
   elseif ($memused > 75) { $memused_status = "warning"; }

--- a/index.php
+++ b/index.php
@@ -118,15 +118,21 @@ $theme_url = 'dist/css/' . $theme;
               <li>
                 <a href="index.php?page=wpa_conf"><i class="fa fa-signal fa-fw"></i> Configure WiFi Client</a>
               </li>
+              <?php if ( RASPI_HOTSPOT_ENABLED ) : ?>
               <li>
                 <a href="index.php?page=hostapd_conf"><i class="fa fa-dot-circle-o fa-fw"></i> Configure Hotspot</a>
               </li>
+              <?php endif; ?>
+              <?php if ( RASPI_NETWORK_ENABLED ) : ?>
               <li>
                 <a href="index.php?page=network_conf"><i class="fa fa-sitemap fa-fw"></i> Configure Networking</a>
               </li> 
+              <?php endif; ?>
+              <?php if ( RASPI_DHCP_ENABLED ) : ?>
               <li>
                 <a href="index.php?page=dhcpd_conf"><i class="fa fa-exchange fa-fw"></i> Configure DHCP Server</a>
               </li>
+              <?php endif; ?>
               <?php if ( RASPI_OPENVPN_ENABLED ) : ?>
               <li>
                 <a href="index.php?page=openvpn_conf"><i class="fa fa-lock fa-fw"></i> Configure OpenVPN</a>
@@ -137,12 +143,16 @@ $theme_url = 'dist/css/' . $theme;
                  <a href="index.php?page=torproxy_conf"><i class="fa fa-eye-slash fa-fw"></i> Configure TOR proxy</a>
               </li>
               <?php endif; ?>
+              <?php if ( RASPI_CONFAUTH_ENABLED ) : ?>
               <li>
                 <a href="index.php?page=auth_conf"><i class="fa fa-lock fa-fw"></i> Configure Auth</a>
               </li>
+              <?php endif; ?>
+              <?php if ( RASPI_CHANGETHEME_ENABLED ) : ?>
               <li>
                 <a href="index.php?page=theme_conf"><i class="fa fa-wrench fa-fw"></i> Change Theme</a>
               </li>
+              <?php endif; ?>
               <li>
                  <a href="index.php?page=system_info"><i class="fa fa-cube fa-fw"></i> System</a>
               </li>


### PR DESCRIPTION
Hi there,

Thank you for the work on this lovely tool.

I added functionalites that others may found useful:

* add global to select wireless interface for wifi client, useful when you use a usb dongle to get wifi
* add globals to select services, useful in a scenario where user would only select a wifi to connect, and you don't whant him to change hotspot or network configuration, 
* fix issue with memory space retrieval, in latest distributions, `free -m` output has changed, it is not anymore in the shape of this [blog post](http://www.markhneedham.com/blog/2013/04/10/awk-parsing-free-m-output-to-get-memory-usageconsumption/)

Best,
Emmanuel