### PR TITLE
Patch dashboard.php to take dots in ESSID's

### DIFF
--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -35,7 +35,7 @@ function DisplayDashboard(){
   $strRxBytes = $result[1];
   preg_match( '/TX Bytes:(\d+ \(\d+.\d+ [K|M|G]iB\))/i',$strWlan0,$result ) || $result[1] = 'No Data';
   $strTxBytes = $result[1];
-  preg_match( '/ESSID:\"([a-zA-Z0-9\s]+)\"/i',$strWlan0,$result ) || $result[1] = 'Not connected';
+  preg_match( '/ESSID:\"([a-zA-Z0-9\s].+)\"/i',$strWlan0,$result ) || $result[1] = 'Not connected';
   $strSSID = str_replace( '"','',$result[1] );
   preg_match( '/Access Point: ([0-9a-f:]+)/i',$strWlan0,$result ) || $result[1] = '';
   $strBSSID = $result[1];


### PR DESCRIPTION
Patched dashboard.php so that the dashboard can display ESSID's that have dots in their names such as "kayton-2.4G". This was done by modifying the regex on line 38.