### PR TITLE
preserve priority in wpa_supplicant.conf

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -138,8 +138,16 @@ function ParseConfig( $arrConfig ) {
 * @return $channel
 */
 function ConvertToChannel( $freq ) {
-  $channel = ($freq - 2407)/5;
-  if ($channel > 0 && $channel < 14) {
+  if ($freq >= 2412 && $freq <= 2484) {
+    $channel = ($freq - 2407)/5;
+  } elseif ($freq >= 4915 && $freq <= 4980) {
+    $channel = ($freq - 4910)/5 + 182;
+  } elseif ($freq >= 5035 && $freq <= 5865) {
+    $channel = ($freq - 5030)/5 + 6;
+  } else {
+    $channel = -1;
+  }
+  if ($channel >= 1 && $channel <= 196) {
     return $channel;
   } else {
     return 'Invalid Channel';

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -214,40 +214,53 @@ function sudo_add() {
 
 # Adds www-data user to the sudoers file with restrictions on what the user can execute
 function patch_system_files() {
+    # add symlink to prevent wpa_cli cmds from breaking with multiple wlan interfaces
+    install_log "symlinked wpa_supplicant hooks for multiple wlan interfaces"
+    sudo ln -s /usr/share/dhcpcd/hooks/10-wpa_supplicant /etc/dhcp/dhclient-enter-hooks.d/
     # Set commands array
     cmds=(
-        '/sbin/ifdown wlan0'
-        '/sbin/ifup wlan0'
-        '/bin/cat /etc/wpa_supplicant/wpa_supplicant.conf'
-        '/bin/cp /tmp/wifidata /etc/wpa_supplicant/wpa_supplicant.conf'
-        '/sbin/wpa_cli scan_results'
-        '/sbin/wpa_cli scan'
-        '/sbin/wpa_cli reconfigure'
-        '/bin/cp /tmp/hostapddata /etc/hostapd/hostapd.conf'
-        '/etc/init.d/hostapd start'
-        '/etc/init.d/hostapd stop'
-        '/etc/init.d/dnsmasq start'
-        '/etc/init.d/dnsmasq stop'
-        '/bin/cp /tmp/dhcpddata /etc/dnsmasq.conf'
-        '/sbin/shutdown -h now'
-        '/sbin/reboot'
-        '/sbin/ip link set wlan0 down'
-        '/sbin/ip link set wlan0 up'
-        '/sbin/ip -s a f label wlan0'
-        '/bin/cp /etc/raspap/networking/dhcpcd.conf /etc/dhcpcd.conf'
-        '/etc/raspap/hostapd/enablelog.sh'
-        '/etc/raspap/hostapd/disablelog.sh'
+        "/sbin/ifdown"
+        "/sbin/ifup"
+        "/bin/cat /etc/wpa_supplicant/wpa_supplicant.conf"
+        "/bin/cat /etc/wpa_supplicant/wpa_supplicant-wlan0.conf"
+        "/bin/cat /etc/wpa_supplicant/wpa_supplicant-wlan1.conf"
+        "/bin/cp /tmp/wifidata /etc/wpa_supplicant/wpa_supplicant.conf"
+        "/bin/cp /tmp/wifidata /etc/wpa_supplicant/wpa_supplicant-wlan0.conf"
+        "/bin/cp /tmp/wifidata /etc/wpa_supplicant/wpa_supplicant-wlan1.conf"
+        "/sbin/wpa_cli scan_results"
+        "/sbin/wpa_cli scan"
+        "/sbin/wpa_cli reconfigure"
+        "/bin/cp /tmp/hostapddata /etc/hostapd/hostapd.conf"
+        "/etc/init.d/hostapd start"
+        "/etc/init.d/hostapd stop"
+        "/etc/init.d/dnsmasq start"
+        "/etc/init.d/dnsmasq stop"
+        "/bin/cp /tmp/dhcpddata /etc/dnsmasq.conf"
+        "/sbin/shutdown -h now"
+        "/sbin/reboot"
+        "/sbin/ip link set wlan0 down"
+        "/sbin/ip link set wlan0 up"
+        "/sbin/ip -s a f label wlan0"
+        "/sbin/ip link set wlan1 down"
+        "/sbin/ip link set wlan1 up"
+        "/sbin/ip -s a f label wlan1"
+        "/bin/cp /etc/raspap/networking/dhcpcd.conf /etc/dhcpcd.conf"
+        "/etc/raspap/hostapd/enablelog.sh"
+        "/etc/raspap/hostapd/disablelog.sh"
     )
 
-    # Check if sudoers needs patchin
-    if [ $(sudo grep -c www-data /etc/sudoers) -ne 15 ]; then
+    # Check if sudoers needs patching
+    if [ $(sudo grep -c www-data /etc/sudoers) -ne 28 ]
+    then
         # Sudoers file has incorrect number of commands. Wiping them out.
         install_log "Cleaning sudoers file"
         sudo sed -i '/www-data/d' /etc/sudoers
         install_log "Patching system sudoers file"
         # patch /etc/sudoers file
-        for cmd in "${cmds[@]}"; do
+        for cmd in "${cmds[@]}"
+        do
             sudo_add $cmd
+            IFS=$'\n'
         done
     else
         install_log "Sudoers file already patched"


### PR DESCRIPTION
I use the priority feature of wpa_supplicant since I have multiple wifi networks available, some better than others. I want to favor the good ones if they're available, and fall back to the others if not. This PR adds functionality to preserve the priority field in wpa_supplicant.conf when making other changes on the WUI. I'm happy to also add the ability to configure it from the WUI, as that would be useful to me, but probably not many others.

I also added some checks to prevent a few errors in the logs. I have some unlisted networks that were throwing errors in DisplayWPAConfig.

There are a few minor formatting changes as well (removing tabs and fixing indentation).

I have tested this and it works for me.