### PR TITLE
Use --depth option during cloning the repo

### DIFF
--- a/installers/common.sh
+++ b/installers/common.sh
@@ -124,7 +124,7 @@ function download_latest_files() {
     fi
 
     install_log "Cloning latest files from github"
-    git clone https://github.com/billz/raspap-webgui /tmp/raspap-webgui || install_error "Unable to download files from github"
+    git clone --depth 1 https://github.com/billz/raspap-webgui /tmp/raspap-webgui || install_error "Unable to download files from github"
     sudo mv /tmp/raspap-webgui $webroot_dir || install_error "Unable to move raspap-webgui to web root"
 }
 


### PR DESCRIPTION
By using option `--depth 1` during cloning the repo, the number of objects to fetch will be decreased from ~10400 to ~220 objects. (about 1.5 MB)