### PR TITLE
Updating revision code list

### DIFF
--- a/includes/system.php
+++ b/includes/system.php
@@ -33,7 +33,13 @@ function RPiVersion() {
     '900093' => 'PiZero 1.3',
     '9000c1' => 'PiZero W',
     'a02082' => 'Pi 3 Model B',
-    'a22082' => 'Pi 3 Model B'
+    'a22082' => 'Pi 3 Model B',
+    'a32082' => 'Pi 3 Model B',
+    'a52082' => 'Pi 3 Model B',
+    'a020d3' => 'Pi 3 Model B+',
+    'a220a0' => 'Compute Module 3',
+    'a020a0' => 'Compute Module 3',
+    'a02100' => 'Compute Module 3+',
   );
 
   $cpuinfo_array = '';


### PR DESCRIPTION
Including missing Pi 3B, CM3+ and 3B+ revision codes.

Based on https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md