### PR TITLE
Changes made using the 'Configure networking' page are not reflected in the actual network configuration Issue #347

### DIFF
--- a/ajax/networking/gen_int_config.php
+++ b/ajax/networking/gen_int_config.php
@@ -4,12 +4,12 @@ include_once('../../includes/config.php');
 include_once('../../includes/functions.php');
 
 if(isset($_POST['generate']) && isset($_POST['csrf_token']) && CSRFValidate()) {
-    $cnfNetworking = array_diff(scandir(RASPI_CONFIG_NETWORKING, 1),array('..','.'));
+    $cnfNetworking = array_diff(scandir(RASPI_CONFIG_NETWORKING, 1),array('..','.','dhcpcd.conf'));
     $cnfNetworking = array_combine($cnfNetworking,$cnfNetworking);
     $strConfFile = "";
     foreach($cnfNetworking as $index=>$file) {
         if($index != "defaults") {
-            $cnfFile = parse_ini_file(RASPI_CONFIG_NETWORKING.'/'.$file);
+            $cnfFile = parse_ini_file(RASPI_CONFIG_NETWORKING.'/'.$file, false, INI_SCANNER_RAW);
             if($cnfFile['static'] === 'true') {
                 $strConfFile .= "interface ".$cnfFile['interface']."\n";
                 $strConfFile .= "static ip_address=".$cnfFile['ip_address']."\n";


### PR DESCRIPTION
Updated ajax/networking/gen_int_config.php 
Changed call to parse_ini_file() to use INI_SCANNER_RAW, so that ini values are parsed as expected;
"true" rather than (Bool)True

see https://github.com/billz/raspap-webgui/issues/347
