### PR TITLE
show network interface settings pre block, properly escaped

### DIFF
--- a/ajax/networking/get_ip_summary.php
+++ b/ajax/networking/get_ip_summary.php
@@ -5,6 +5,7 @@ include_once('../../includes/functions.php');
 if(isset($_POST['interface']) && isset($_POST['csrf_token']) && CSRFValidate()) {
     $int = preg_replace('/[^a-z0-9]/','',$_POST['interface']);
     exec('ip a s '.$int,$intOutput,$intResult);
+    $intOutput = array_map('htmlentities', $intOutput);
     $jsonData = ['return'=>$intResult,'output'=>$intOutput];
     echo json_encode($jsonData);
 } else {

--- a/dist/css/custom.css
+++ b/dist/css/custom.css
@@ -53,3 +53,9 @@
     width:100%;
     height:300px;
 }
+
+pre.unstyled {
+    border-width: 0;
+    background-color: transparent;
+    padding: 0;
+}

--- a/includes/networking.php
+++ b/includes/networking.php
@@ -44,7 +44,9 @@ function DisplayNetworkingConfig()
                             echo '<div class="col-md-6">
                             <div class="panel panel-default">
                                 <div class="panel-heading">'.htmlspecialchars($interface, ENT_QUOTES).'</div>
-                                <div class="panel-body" id="'.htmlspecialchars($interface, ENT_QUOTES).'-summary"></div>
+                                <div class="panel-body">
+                                  <pre class="unstyled" id="'.htmlspecialchars($interface, ENT_QUOTES).'-summary"></pre>
+                                </div>
                             </div>
                             </div>';
                         }


### PR DESCRIPTION
the output of `ip address show` contains critical characters for html, e.g., `<BROADCAST,MULTICAST,UP,LOWER_UP>`.

```
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether b8:27:eb:9a:38:49 brd ff:ff:ff:ff:ff:ff
    inet 192.168.178.33/24 brd 192.168.178.255 scope global noprefixroute eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::ba27:ebff:fe9a:3849/64 scope link
       valid_lft forever preferred_lft forever
```

just putting this into the page -- in this case via xhr -- will lead to arbitrary html elements being created and information hidden. i think showing the output verbatim, while ugly, is more readable and does not omit information.

| before | after |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/201135/62128879-ad7ded00-b2d5-11e9-8add-b4a8a04b8978.png) | ![after](https://user-images.githubusercontent.com/201135/62128899-bcfd3600-b2d5-11e9-8787-24381cef68f6.png) |
