### PR TITLE
always verify csrf token for resource-modifying requests

### DIFF
--- a/ajax/bandwidth/get_bandwidth.php
+++ b/ajax/bandwidth/get_bandwidth.php
@@ -1,8 +1,10 @@
 <?php
+
+require('includes/csrf.php');
+
 require_once '../../includes/config.php';
 require_once RASPI_CONFIG.'/raspap.php';
 
-session_start();
 header('X-Frame-Options: DENY');
 header("Content-Security-Policy: default-src 'none'; connect-src 'self'");
 require_once '../../includes/authenticate.php';

--- a/ajax/bandwidth/get_bandwidth_hourly.php
+++ b/ajax/bandwidth/get_bandwidth_hourly.php
@@ -1,4 +1,7 @@
 <?php 
+
+require('includes/csrf.php');
+
 if (filter_input(INPUT_GET, 'tu') == 'h') {
 
 	header('X-Content-Type-Options: nosniff');

--- a/ajax/networking/gen_int_config.php
+++ b/ajax/networking/gen_int_config.php
@@ -1,5 +1,7 @@
 <?php
-session_start();
+
+require('includes/csrf.php');
+
 include_once('../../includes/config.php');
 include_once('../../includes/functions.php');
 

--- a/ajax/networking/gen_int_config.php
+++ b/ajax/networking/gen_int_config.php
@@ -3,7 +3,7 @@ session_start();
 include_once('../../includes/config.php');
 include_once('../../includes/functions.php');
 
-if(isset($_POST['generate']) && isset($_POST['csrf_token']) && CSRFValidate()) {
+if(isset($_POST['generate'])) {
     $cnfNetworking = array_diff(scandir(RASPI_CONFIG_NETWORKING, 1),array('..','.','dhcpcd.conf'));
     $cnfNetworking = array_combine($cnfNetworking,$cnfNetworking);
     $strConfFile = "";

--- a/ajax/networking/get_all_interfaces.php
+++ b/ajax/networking/get_all_interfaces.php
@@ -1,4 +1,7 @@
 <?php
+
+    require('includes/csrf.php');
+
     exec("ls /sys/class/net | grep -v lo", $interfaces);
     echo json_encode($interfaces);
 ?>

--- a/ajax/networking/get_int_config.php
+++ b/ajax/networking/get_int_config.php
@@ -1,5 +1,7 @@
 <?php
-session_start();
+
+require('includes/csrf.php');
+
 include_once('../../includes/config.php');
 include_once('../../includes/functions.php');
 

--- a/ajax/networking/get_int_config.php
+++ b/ajax/networking/get_int_config.php
@@ -4,7 +4,7 @@ include_once('../../includes/config.php');
 include_once('../../includes/functions.php');
 
 
-if(isset($_POST['interface']) && isset($_POST['csrf_token']) && CSRFValidate()) {
+if(isset($_POST['interface'])) {
     $int = preg_replace('/[^a-z0-9]/', '', $_POST['interface']);
     if(!file_exists(RASPI_CONFIG_NETWORKING.'/'.$int.'.ini')) {
         touch(RASPI_CONFIG_NETWORKING.'/'.$int.'.ini');

--- a/ajax/networking/get_ip_summary.php
+++ b/ajax/networking/get_ip_summary.php
@@ -2,7 +2,7 @@
 session_start();
 include_once('../../includes/functions.php');
 
-if(isset($_POST['interface']) && isset($_POST['csrf_token']) && CSRFValidate()) {
+if(isset($_POST['interface'])) {
     $int = preg_replace('/[^a-z0-9]/','',$_POST['interface']);
     exec('ip a s '.$int,$intOutput,$intResult);
     $intOutput = array_map('htmlentities', $intOutput);

--- a/ajax/networking/get_ip_summary.php
+++ b/ajax/networking/get_ip_summary.php
@@ -1,5 +1,7 @@
 <?php
-session_start();
+
+require('includes/csrf.php');
+
 include_once('../../includes/functions.php');
 
 if(isset($_POST['interface'])) {

--- a/ajax/networking/save_int_config.php
+++ b/ajax/networking/save_int_config.php
@@ -1,5 +1,7 @@
 <?php
-    session_start();
+
+    require('includes/csrf.php');
+
     include_once('../../includes/config.php');
     include_once('../../includes/functions.php');
     if(isset($_POST['interface'])) {

--- a/ajax/networking/save_int_config.php
+++ b/ajax/networking/save_int_config.php
@@ -2,7 +2,7 @@
     session_start();
     include_once('../../includes/config.php');
     include_once('../../includes/functions.php');
-    if(isset($_POST['interface']) && isset($_POST['csrf_token']) && CSRFValidate()) {
+    if(isset($_POST['interface'])) {
         $int = $_POST['interface'];
         $cfg = [];
         $file = $int.".ini";

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -6,34 +6,30 @@ function DisplayAuthConfig($username, $password)
 {
     $status = new StatusMessages();
     if (isset($_POST['UpdateAdminPassword'])) {
-        if (CSRFValidate()) {
-            if (password_verify($_POST['oldpass'], $password)) {
-                $new_username=trim($_POST['username']);
-                if ($_POST['newpass'] !== $_POST['newpassagain']) {
-                    $status->addMessage('New passwords do not match', 'danger');
-                } elseif ($new_username == '') {
-                    $status->addMessage('Username must not be empty', 'danger');
-                } else {
-                    if (!file_exists(RASPI_ADMIN_DETAILS)) {
-                        $tmpauth = fopen(RASPI_ADMIN_DETAILS, 'w');
-                        fclose($tmpauth);
-                    }
-
-                    if ($auth_file = fopen(RASPI_ADMIN_DETAILS, 'w')) {
-                        fwrite($auth_file, $new_username.PHP_EOL);
-                        fwrite($auth_file, password_hash($_POST['newpass'], PASSWORD_BCRYPT).PHP_EOL);
-                        fclose($auth_file);
-                        $username = $new_username;
-                        $status->addMessage('Admin password updated');
-                    } else {
-                        $status->addMessage('Failed to update admin password', 'danger');
-                    }
-                }
+        if (password_verify($_POST['oldpass'], $password)) {
+            $new_username=trim($_POST['username']);
+            if ($_POST['newpass'] !== $_POST['newpassagain']) {
+                $status->addMessage('New passwords do not match', 'danger');
+            } elseif ($new_username == '') {
+                $status->addMessage('Username must not be empty', 'danger');
             } else {
-                $status->addMessage('Old password does not match', 'danger');
+                if (!file_exists(RASPI_ADMIN_DETAILS)) {
+                    $tmpauth = fopen(RASPI_ADMIN_DETAILS, 'w');
+                    fclose($tmpauth);
+                }
+
+                if ($auth_file = fopen(RASPI_ADMIN_DETAILS, 'w')) {
+                    fwrite($auth_file, $new_username.PHP_EOL);
+                    fwrite($auth_file, password_hash($_POST['newpass'], PASSWORD_BCRYPT).PHP_EOL);
+                    fclose($auth_file);
+                    $username = $new_username;
+                    $status->addMessage('Admin password updated');
+                } else {
+                    $status->addMessage('Failed to update admin password', 'danger');
+                }
             }
         } else {
-            error_log('CSRF violation');
+            $status->addMessage('Old password does not match', 'danger');
         }
     }
 ?>

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -40,7 +40,7 @@ function DisplayAuthConfig($username, $password)
         <div class="panel-body">
           <p><?php $status->showMessages(); ?></p>
           <form role="form" action="?page=auth_conf" method="POST">
-            <?php echo CSRFToken() ?>
+            <?php echo CSRFTokenFieldTag() ?>
             <div class="row">
               <div class="form-group col-md-4">
                 <label for="username"><?php echo _("Username"); ?></label>

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -40,7 +40,7 @@ function DisplayAuthConfig($username, $password)
         <div class="panel-body">
           <p><?php $status->showMessages(); ?></p>
           <form role="form" action="?page=auth_conf" method="POST">
-            <?php CSRFToken() ?>
+            <?php echo CSRFToken() ?>
             <div class="row">
               <div class="form-group col-md-4">
                 <label for="username"><?php echo _("Username"); ?></label>

--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -53,7 +53,7 @@ function DisplayWPAConfig()
     if (isset($_POST['connect'])) {
         $result = 0;
         exec('sudo wpa_cli -i ' . RASPI_WPA_CTRL_INTERFACE . ' select_network '.strval($_POST['connect']));
-    } elseif (isset($_POST['client_settings']) && CSRFValidate()) {
+    } elseif (isset($_POST['client_settings'])) {
         $tmp_networks = $networks;
         if ($wpa_file = fopen('/tmp/wifidata', 'w')) {
             fwrite($wpa_file, 'ctrl_interface=DIR=' . RASPI_WPA_CTRL_INTERFACE . ' GROUP=netdev' . PHP_EOL);

--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -182,7 +182,7 @@ function DisplayWPAConfig()
             </div> 
 
             <form method="POST" action="?page=wpa_conf" name="wpa_conf_form">
-                <?php echo CSRFToken() ?>
+                <?php echo CSRFTokenFieldTag() ?>
               <input type="hidden" name="client_settings" ?>
               <script>
                 function showPassword(index) {

--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -182,7 +182,7 @@ function DisplayWPAConfig()
             </div> 
 
             <form method="POST" action="?page=wpa_conf" name="wpa_conf_form">
-                <?php CSRFToken() ?>
+                <?php echo CSRFToken() ?>
               <input type="hidden" name="client_settings" ?>
               <script>
                 function showPassword(index) {

--- a/includes/csrf.php
+++ b/includes/csrf.php
@@ -1,0 +1,11 @@
+<?php
+
+include_once('includes/functions.php');
+include_once('includes/session.php');
+
+if (csrfValidateRequest() && !CSRFValidate()) {
+  handleInvalidCSRFToken();
+}
+
+ensureCSRFSessionToken();
+header('X-CSRF-Token', $_SESSION['csrf_token']);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -68,6 +68,15 @@ function CSRFToken()
 }
 
 /**
+* Retuns a CSRF meta tag (for use with xhr, for example)
+*/
+function CSRFMetaTag()
+{
+    $token = htmlspecialchars($_SESSION['csrf_token']);
+    return '<meta name="csrf_token" content="' . $token . '">';
+}
+
+/**
 *
 * Validate CSRF Token
 *

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -67,7 +67,7 @@ function ensureCSRFSessionToken()
 * Add CSRF Token to form
 *
 */
-function CSRFToken()
+function CSRFTokenFieldTag()
 {
     $token = htmlspecialchars($_SESSION['csrf_token']);
     return '<input id="csrf_token" type="hidden" name="csrf_token" value="' . $token . '">';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -59,9 +59,7 @@ function safefilerewrite($fileName, $dataToSave)
 */
 function ensureCSRFSessionToken()
 {
-    if (empty($_SESSION['csrf_token'])) {
-        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
-    }
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -70,8 +70,7 @@ function ensureCSRFSessionToken()
 function CSRFToken()
 {
 ?>
-<input id="csrf_token" type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES);
-; ?>" />
+<input id="csrf_token" type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES); ?>" />
 <?php
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -83,7 +83,19 @@ function CSRFMetaTag()
 */
 function CSRFValidate()
 {
-    if (hash_equals($_POST['csrf_token'], $_SESSION['csrf_token'])) {
+    $post_token   = $_POST['csrf_token'];
+    $header_token = $_SERVER['HTTP_X_CSRF_TOKEN'];
+
+    if (empty($post_token) && empty($header_token)) {
+        return false;
+    }
+
+    $request_token = $post_token;
+    if (empty($post_token)) {
+        $request_token = $header_token;
+    }
+
+    if (hash_equals($_SESSION['csrf_token'], $request_token)) {
         return true;
     } else {
         error_log('CSRF violation');

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -69,9 +69,8 @@ function ensureCSRFSessionToken()
 */
 function CSRFToken()
 {
-?>
-<input id="csrf_token" type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES); ?>" />
-<?php
+    $token = htmlspecialchars($_SESSION['csrf_token']);
+    echo '<input id="csrf_token" type="hidden" name="csrf_token" value="' . $token . '">';
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -70,7 +70,7 @@ function ensureCSRFSessionToken()
 function CSRFToken()
 {
     $token = htmlspecialchars($_SESSION['csrf_token']);
-    echo '<input id="csrf_token" type="hidden" name="csrf_token" value="' . $token . '">';
+    return '<input id="csrf_token" type="hidden" name="csrf_token" value="' . $token . '">';
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -60,11 +60,7 @@ function safefilerewrite($fileName, $dataToSave)
 function ensureCSRFSessionToken()
 {
     if (empty($_SESSION['csrf_token'])) {
-        if (function_exists('mcrypt_create_iv')) {
-            $_SESSION['csrf_token'] = bin2hex(mcrypt_create_iv(32, MCRYPT_DEV_URANDOM));
-        } else {
-            $_SESSION['csrf_token'] = bin2hex(openssl_random_pseudo_bytes(32));
-        }
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
     }
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -70,7 +70,7 @@ function ensureCSRFSessionToken()
 function CSRFTokenFieldTag()
 {
     $token = htmlspecialchars($_SESSION['csrf_token']);
-    return '<input id="csrf_token" type="hidden" name="csrf_token" value="' . $token . '">';
+    return '<input type="hidden" name="csrf_token" value="' . $token . '">';
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -83,6 +83,26 @@ function CSRFValidate()
 }
 
 /**
+* Should the request be CSRF-validated?
+*/
+function csrfValidateRequest()
+{
+  $request_method = strtolower($_SERVER['REQUEST_METHOD']);
+  return in_array($request_method, [ "post", "put", "patch", "delete" ]);
+}
+
+/**
+* Handle invalid CSRF
+*/
+function handleInvalidCSRFToken()
+{
+    header('HTTP/1.1 500 Internal Server Error');
+    header('Content-Type: text/plain');
+    echo 'Invalid CSRF token';
+    exit;
+}
+
+/**
 * Test whether array is associative
 */
 function isAssoc($arr)

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -55,6 +55,20 @@ function safefilerewrite($fileName, $dataToSave)
 }
 
 /**
+* Saves a CSRF token in the session
+*/
+function ensureCSRFSessionToken()
+{
+    if (empty($_SESSION['csrf_token'])) {
+        if (function_exists('mcrypt_create_iv')) {
+            $_SESSION['csrf_token'] = bin2hex(mcrypt_create_iv(32, MCRYPT_DEV_URANDOM));
+        } else {
+            $_SESSION['csrf_token'] = bin2hex(openssl_random_pseudo_bytes(32));
+        }
+    }
+}
+
+/**
 *
 * Add CSRF Token to form
 *

--- a/includes/hostapd.php
+++ b/includes/hostapd.php
@@ -83,7 +83,7 @@ function DisplayHostAPDConfig()
                 <div class="tab-pane fade in active" id="basic">
 
                 <h4><?php echo _("Basic settings") ;?></h4>
-                <?php CSRFToken() ?>
+                <?php echo CSRFToken() ?>
                 <div class="row">
                   <div class="form-group col-md-4">
                     <label for="cbxinterface"><?php echo _("Interface") ;?></label>

--- a/includes/hostapd.php
+++ b/includes/hostapd.php
@@ -83,7 +83,7 @@ function DisplayHostAPDConfig()
                 <div class="tab-pane fade in active" id="basic">
 
                 <h4><?php echo _("Basic settings") ;?></h4>
-                <?php echo CSRFToken() ?>
+                <?php echo CSRFTokenFieldTag() ?>
                 <div class="row">
                   <div class="form-group col-md-4">
                     <label for="cbxinterface"><?php echo _("Interface") ;?></label>

--- a/includes/hostapd.php
+++ b/includes/hostapd.php
@@ -22,34 +22,22 @@ function DisplayHostAPDConfig()
     exec("ip -o link show | awk -F': ' '{print $2}'", $interfaces);
 
     if (isset($_POST['SaveHostAPDSettings'])) {
-        if (CSRFValidate()) {
-            SaveHostAPDConfig($arrSecurity, $arrEncType, $arr80211Standard, $interfaces, $status);
-        } else {
-            error_log('CSRF violation');
-        }
+        SaveHostAPDConfig($arrSecurity, $arrEncType, $arr80211Standard, $interfaces, $status);
     } elseif (isset($_POST['StartHotspot'])) {
-        if (CSRFValidate()) {
-            $status->addMessage('Attempting to start hotspot', 'info');
-            if ($arrHostapdConf['WifiAPEnable'] == 1) {
-                exec('sudo /etc/raspap/hostapd/servicestart.sh --interface uap0 --seconds 3', $return);
-            } else {
-                exec('sudo /etc/raspap/hostapd/servicestart.sh --seconds 5', $return);
-            }
-            foreach ($return as $line) {
-                $status->addMessage($line, 'info');
-            }
+        $status->addMessage('Attempting to start hotspot', 'info');
+        if ($arrHostapdConf['WifiAPEnable'] == 1) {
+            exec('sudo /etc/raspap/hostapd/servicestart.sh --interface uap0 --seconds 3', $return);
         } else {
-            error_log('CSRF violation');
+            exec('sudo /etc/raspap/hostapd/servicestart.sh --seconds 5', $return);
+        }
+        foreach ($return as $line) {
+            $status->addMessage($line, 'info');
         }
     } elseif (isset($_POST['StopHotspot'])) {
-        if (CSRFValidate()) {
-            $status->addMessage('Attempting to stop hotspot', 'info');
-            exec('sudo /etc/init.d/hostapd stop', $return);
-            foreach ($return as $line) {
-                $status->addMessage($line, 'info');
-            }
-        } else {
-            error_log('CSRF violation');
+        $status->addMessage('Attempting to stop hotspot', 'info');
+        exec('sudo /etc/init.d/hostapd stop', $return);
+        foreach ($return as $line) {
+            $status->addMessage($line, 'info');
         }
     }
 

--- a/includes/networking.php
+++ b/includes/networking.php
@@ -16,8 +16,6 @@ function DisplayNetworkingConfig()
     foreach ($interfaces as $interface) {
         exec("ip a show $interface", $$interface);
     }
-
-    CSRFToken();
 ?>
 
 <div class="row">

--- a/includes/session.php
+++ b/includes/session.php
@@ -1,0 +1,5 @@
+<?php
+
+if (session_status() == PHP_SESSION_NONE) {
+  session_start();
+}

--- a/includes/system.php
+++ b/includes/system.php
@@ -200,7 +200,7 @@ if (isset($_POST['system_shutdown'])) {
 
     <div role="tabpanel" class="tab-pane" id="language">
       <h4><?php echo _("Language settings") ;?></h4>
-        <?php CSRFToken() ?>
+        <?php echo CSRFToken() ?>
       <div class="row">
         <div class="form-group col-md-4">
           <label for="code"><?php echo _("Select a language"); ?></label>

--- a/includes/system.php
+++ b/includes/system.php
@@ -63,13 +63,9 @@ function DisplaySystem()
     $status = new StatusMessages();
 
     if (isset($_POST['SaveLanguage'])) {
-        if (CSRFValidate()) {
-            if (isset($_POST['locale'])) {
-                $_SESSION['locale'] = $_POST['locale'];
-                $status->addMessage('Language setting saved', 'success');
-            }
-        } else {
-            error_log('CSRF violation');
+        if (isset($_POST['locale'])) {
+            $_SESSION['locale'] = $_POST['locale'];
+            $status->addMessage('Language setting saved', 'success');
         }
     }
 

--- a/includes/system.php
+++ b/includes/system.php
@@ -200,7 +200,7 @@ if (isset($_POST['system_shutdown'])) {
 
     <div role="tabpanel" class="tab-pane" id="language">
       <h4><?php echo _("Language settings") ;?></h4>
-        <?php echo CSRFToken() ?>
+        <?php echo CSRFTokenFieldTag() ?>
       <div class="row">
         <div class="form-group col-md-4">
           <label for="code"><?php echo _("Select a language"); ?></label>

--- a/index.php
+++ b/index.php
@@ -18,7 +18,7 @@
  * @see        http://sirlagz.net/2013/02/08/raspap-webgui/
  */
 
-session_start();
+require('includes/csrf.php');
 
 include_once('includes/config.php');
 include_once(RASPI_CONFIG.'/raspap.php');
@@ -38,12 +38,6 @@ include_once('includes/about.php');
 
 $output = $return = 0;
 $page = $_GET['page'];
-
-if (csrfValidateRequest() && !CSRFValidate()) {
-  handleInvalidCSRFToken();
-}
-
-ensureCSRFSessionToken();
 
 if (!isset($_COOKIE['theme'])) {
     $theme = "custom.css";

--- a/index.php
+++ b/index.php
@@ -39,6 +39,10 @@ include_once('includes/about.php');
 $output = $return = 0;
 $page = $_GET['page'];
 
+if (csrfValidateRequest() && !CSRFValidate()) {
+  handleInvalidCSRFToken();
+}
+
 if (empty($_SESSION['csrf_token'])) {
     if (function_exists('mcrypt_create_iv')) {
         $_SESSION['csrf_token'] = bin2hex(mcrypt_create_iv(32, MCRYPT_DEV_URANDOM));

--- a/index.php
+++ b/index.php
@@ -50,7 +50,6 @@ if (empty($_SESSION['csrf_token'])) {
         $_SESSION['csrf_token'] = bin2hex(openssl_random_pseudo_bytes(32));
     }
 }
-$csrf_token = $_SESSION['csrf_token'];
 
 if (!isset($_COOKIE['theme'])) {
     $theme = "custom.css";

--- a/index.php
+++ b/index.php
@@ -43,13 +43,7 @@ if (csrfValidateRequest() && !CSRFValidate()) {
   handleInvalidCSRFToken();
 }
 
-if (empty($_SESSION['csrf_token'])) {
-    if (function_exists('mcrypt_create_iv')) {
-        $_SESSION['csrf_token'] = bin2hex(mcrypt_create_iv(32, MCRYPT_DEV_URANDOM));
-    } else {
-        $_SESSION['csrf_token'] = bin2hex(openssl_random_pseudo_bytes(32));
-    }
-}
+ensureCSRFSessionToken();
 
 if (!isset($_COOKIE['theme'])) {
     $theme = "custom.css";

--- a/index.php
+++ b/index.php
@@ -64,6 +64,7 @@ $theme_url = 'dist/css/'.htmlspecialchars($theme, ENT_QUOTES);
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <?php echo CSRFMetaTag() ?>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">

--- a/js/custom.js
+++ b/js/custom.js
@@ -162,6 +162,15 @@ function setupBtns() {
     });
 }
 
+$.ajaxSetup({
+    beforeSend: function(xhr, settings) {
+        var csrfToken = $('meta[name=csrf_token]').attr('content');
+        if (/^(POST|PATCH|PUT|DELETE)$/i.test(settings.type)) {
+            xhr.setRequestHeader("X-CSRF-Token", csrfToken);
+        }
+    }
+});
+
 $().ready(function(){
     csrf = $('#csrf_token').val();
     pageCurrent = window.location.href.split("?")[1].split("=")[1];

--- a/js/custom.js
+++ b/js/custom.js
@@ -175,11 +175,7 @@ function updateCSRFTokens(event, xhr, settings) {
     }
 }
 
-$(document)
-    .ajaxSend(setCSRFTokenHeader)
-    .ajaxComplete(updateCSRFTokens);
-
-$().ready(function(){
+function contentLoaded() {
     pageCurrent = window.location.href.split("?")[1].split("=")[1];
     pageCurrent = pageCurrent.replace("#","");
     $('#side-menu').metisMenu();
@@ -190,6 +186,9 @@ $().ready(function(){
             setupBtns();
         break;
     }
-});
+}
 
-
+$(document)
+    .ajaxSend(setCSRFTokenHeader)
+    .ajaxComplete(updateCSRFTokens)
+    .ready(contentLoaded);

--- a/js/custom.js
+++ b/js/custom.js
@@ -160,7 +160,14 @@ function setupBtns() {
     });
 }
 
-function updateCSRFToken(xhr, settings) {
+function setCSRFTokenHeader(event, xhr, settings) {
+    var csrfToken = $('meta[name=csrf_token]').attr('content');
+    if (/^(POST|PATCH|PUT|DELETE)$/i.test(settings.type)) {
+        xhr.setRequestHeader("X-CSRF-Token", csrfToken);
+    }
+}
+
+function updateCSRFTokens(event, xhr, settings) {
     var newToken = xhr.getResponseHeader("X-CSRF-Token");
     if (newToken) {
         $('meta[name=csrf_token]').attr('content', newToken);
@@ -168,15 +175,9 @@ function updateCSRFToken(xhr, settings) {
     }
 }
 
-$.ajaxSetup({
-    beforeSend: function(xhr, settings) {
-        var csrfToken = $('meta[name=csrf_token]').attr('content');
-        if (/^(POST|PATCH|PUT|DELETE)$/i.test(settings.type)) {
-            xhr.setRequestHeader("X-CSRF-Token", csrfToken);
-        }
-    },
-    ajaxComplete: updateCSRFToken
-});
+$(document)
+    .ajaxSend(setCSRFTokenHeader)
+    .ajaxComplete(updateCSRFTokens);
 
 $().ready(function(){
     pageCurrent = window.location.href.split("?")[1].split("=")[1];

--- a/js/custom.js
+++ b/js/custom.js
@@ -160,13 +160,22 @@ function setupBtns() {
     });
 }
 
+function updateCSRFToken(xhr, settings) {
+    var newToken = xhr.getResponseHeader("X-CSRF-Token");
+    if (newToken) {
+        $('meta[name=csrf_token]').attr('content', newToken);
+        $('[name=csrf_token]:input').attr('value', newToken);
+    }
+}
+
 $.ajaxSetup({
     beforeSend: function(xhr, settings) {
         var csrfToken = $('meta[name=csrf_token]').attr('content');
         if (/^(POST|PATCH|PUT|DELETE)$/i.test(settings.type)) {
             xhr.setRequestHeader("X-CSRF-Token", csrfToken);
         }
-    }
+    },
+    ajaxComplete: updateCSRFToken
 });
 
 $().ready(function(){

--- a/js/custom.js
+++ b/js/custom.js
@@ -19,7 +19,7 @@ function createNetmaskAddr(bitCount) {
 }
 
 function loadSummary(strInterface) {
-    $.post('/ajax/networking/get_ip_summary.php',{interface:strInterface,csrf_token:csrf},function(data){
+    $.post('/ajax/networking/get_ip_summary.php',{interface:strInterface},function(data){
         jsonData = JSON.parse(data);
         console.log(jsonData);
         if(jsonData['return'] == 0) {
@@ -50,7 +50,7 @@ function setupTabs() {
 }
 
 function loadCurrentSettings(strInterface) {
-    $.post('/ajax/networking/get_int_config.php',{interface:strInterface,csrf_token:csrf},function(data){
+    $.post('/ajax/networking/get_int_config.php',{interface:strInterface},function(data){
         jsonData = JSON.parse(data);
         $.each(jsonData['output'],function(i,v) {
             var int = v['interface'];
@@ -102,7 +102,6 @@ function saveNetworkSettings(int) {
             }
         });
         arrFormData['interface'] = int;
-        arrFormData['csrf_token'] = csrf;
         $.post('/ajax/networking/save_int_config.php',arrFormData,function(data){
             //console.log(data);
             var jsonData = JSON.parse(data);
@@ -113,7 +112,6 @@ function saveNetworkSettings(int) {
 function applyNetworkSettings() {
         var int = $(this).data('int');
         arrFormData = {};
-        arrFormData['csrf_token'] = csrf;
         arrFormData['generate'] = '';
         $.post('/ajax/networking/gen_int_config.php',arrFormData,function(data){
             console.log(data);
@@ -172,7 +170,6 @@ $.ajaxSetup({
 });
 
 $().ready(function(){
-    csrf = $('#csrf_token').val();
     pageCurrent = window.location.href.split("?")[1].split("=")[1];
     pageCurrent = pageCurrent.replace("#","");
     $('#side-menu').metisMenu();


### PR DESCRIPTION
looking through the code to make other improvements i came across some inefficiencies regarding csrf handling. i'm not saying it's insecure. i just have a more generic implementation.

1. there‘s a csrf token in the session; _every_ resource-modifying request (post, put, patch, delete) is potentially destructive and should be verified.
2. to be able to verify each request, ensure a token is present either as part of the payload data or in a header. the param takes precedent over the header.
3. use jquery‘s `beforeSend` callback to add the token from a csrf meta tag as header to each request. this removes the need to do it manually on each `$.post` call from js.
4. decrease predictability by generating a new token on each request. it only needs to survive one request-response-cycle anyway.
5. token verification happens as early as possible and fails with http status code 500.
6. remove duplicated code regarding csrf injection. this reduces conditional complexity and if-else-branching.

