### PR TITLE
SECURITY ISSUE! fix command injection

### DIFF
--- a/includes/dhcp.php
+++ b/includes/dhcp.php
@@ -48,7 +48,7 @@ function DisplayDHCPConfig()
                 }
 
                 $config .= $_POST['RangeLeaseTimeUnits'];
-                exec('echo "'.$config.'" > /tmp/dhcpddata', $temp);
+                file_put_contents("/tmp/dhcpddata", $config);
                 system('sudo cp /tmp/dhcpddata '.RASPI_DNSMASQ_CONFIG, $return);
             } else {
                 $status->addMessage($errors, 'danger');

--- a/includes/hostapd.php
+++ b/includes/hostapd.php
@@ -655,8 +655,8 @@ function SaveHostAPDConfig($wpa_array, $enc_types, $modes, $interfaces, $status)
             $config.= 'interface='.$_POST['interface'].PHP_EOL;
             $config.= 'dhcp-range=10.3.141.50,10.3.141.255,255.255.255.0,12h'.PHP_EOL;
         }
-        file_put_contents("/tmp/dhcpddata", $config);
-        system('sudo cp /tmp/dhcpddata '.RASPI_DNSMASQ_CONFIG, $return);
+        file_put_contents("/tmp/dnsmasqdata", $config);
+        system('sudo cp /tmp/dnsmasqdata '.RASPI_DNSMASQ_CONFIG, $return);
 
         if ($wifiAPEnable == 1) {
             // Enable uap0 configuration in dhcpcd for Wifi client AP mode

--- a/includes/hostapd.php
+++ b/includes/hostapd.php
@@ -638,7 +638,7 @@ function SaveHostAPDConfig($wpa_array, $enc_types, $modes, $interfaces, $status)
         $config.= 'country_code='.$_POST['country_code'].PHP_EOL;
         $config.= 'ignore_broadcast_ssid='.$ignore_broadcast_ssid.PHP_EOL;
 
-        exec('echo "'.$config.'" > /tmp/hostapddata', $temp);
+        file_put_contents("/tmp/hostapddata", $config);
         system("sudo cp /tmp/hostapddata " . RASPI_HOSTAPD_CONFIG, $return);
 
         if ($wifiAPEnable == 1) {
@@ -655,7 +655,7 @@ function SaveHostAPDConfig($wpa_array, $enc_types, $modes, $interfaces, $status)
             $config.= 'interface='.$_POST['interface'].PHP_EOL;
             $config.= 'dhcp-range=10.3.141.50,10.3.141.255,255.255.255.0,12h'.PHP_EOL;
         }
-        exec('echo "'.$config.'" > /tmp/dhcpddata', $temp);
+        file_put_contents("/tmp/dhcpddata", $config);
         system('sudo cp /tmp/dhcpddata '.RASPI_DNSMASQ_CONFIG, $return);
 
         if ($wifiAPEnable == 1) {
@@ -682,7 +682,7 @@ function SaveHostAPDConfig($wpa_array, $enc_types, $modes, $interfaces, $status)
             $config.= 'static routers=10.3.141.1'.PHP_EOL;
             $config.= 'static domain_name_server=1.1.1.1 8.8.8.8'.PHP_EOL;
         }
-        exec('echo "'.$config.'" > /tmp/dhcpddata', $temp);
+        file_put_contents("/tmp/dhcpddata", $config);
         system('sudo cp /tmp/dhcpddata '.RASPI_DHCPCD_CONFIG, $return);
 
 


### PR DESCRIPTION
as reported in #354, special characters lead to weird behavior after saving a password in the hostapd config section. after further inspection, this is actually a command injection issue, allowing code execution on the shell.

1. in "configure hotspot" > tab "security" enter the following into the field
"psk": `$(cat /etc/raspap/raspap.auth|tail -1)`.
2. press "save settings".
3. go back to tab "security". the field "psk" will now contain the last line of that file (which is the basic auth password hash).

the underlying issue is the way the hostapd config is being written to disk:

```php
exec('echo "'.$config.'" > /tmp/hostapddata', $temp);
```

because anything in `$config` is being passed directly to the shell commands like the one above will be evaluated and its result written to the `wpa_passphrase` option of the hostapd config file.

this patch fixes this and finally allows usage of the dollar sign in wpa passphrases.