### PR TITLE
static dhcp leases

### DIFF
--- a/dist/css/custom.css
+++ b/dist/css/custom.css
@@ -53,3 +53,13 @@
     width:100%;
     height:300px;
 }
+
+.dhcp-static-leases {
+	margin-top: 1em;
+	margin-bottom: 1em;
+}
+
+.dhcp-static-lease-row {
+	margin-top: 0.5em;
+	margin-bottom: 0.5em;
+}

--- a/includes/dhcp.php
+++ b/includes/dhcp.php
@@ -156,7 +156,7 @@ function DisplayDHCPConfig()
         <!-- /.panel-heading -->
         <div class="panel-body">
         <p><?php $status->showMessages(); ?></p>
-        <form method="POST" action="?page=dhcpd_conf">
+        <form method="POST" action="?page=dhcpd_conf" class="js-dhcp-settings-form">
         <?php CSRFToken() ?>
         <!-- Nav tabs -->
             <ul class="nav nav-tabs">

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -145,9 +145,17 @@ function ParseConfig($arrConfig)
     $config = array();
     foreach ($arrConfig as $line) {
         $line = trim($line);
-        if ($line != "" && $line[0] != "#") {
-            $arrLine = explode("=", $line);
-            $config[$arrLine[0]] = ( count($arrLine) > 1 ? $arrLine[1] : true );
+        if ($line == "" || $line[0] == "#") { continue; }
+
+        list($option, $value) = array_map("trim", explode("=", $line, 2));
+
+        if (empty($config[$option])) {
+            $config[$option] = $value ?: true;
+        } else {
+            if (!is_array($config[$option])) {
+                $config[$option] = [ $config[$option] ];
+            }
+            $config[$option][] = $value;
         }
     }
     return $config;

--- a/js/custom.js
+++ b/js/custom.js
@@ -145,6 +145,10 @@ $(document).on("click", ".js-remove-dhcp-static-lease", function(e) {
     $(this).parents(".js-dhcp-static-lease-row").remove();
 });
 
+$(document).on("submit", ".js-dhcp-settings-form", function(e) {
+    $(".js-add-dhcp-static-lease").trigger("click");
+});
+
 function setupBtns() {
     $('#btnSummaryRefresh').click(function(){getAllInterfaces();});
 

--- a/js/custom.js
+++ b/js/custom.js
@@ -122,6 +122,29 @@ function applyNetworkSettings() {
         });
 }
 
+$(document).on("click", ".js-add-dhcp-static-lease", function(e) {
+    e.preventDefault();
+    var container = $(".js-new-dhcp-static-lease");
+    var mac = $("input[name=mac]", container).val().trim();
+    var ip  = $("input[name=ip]", container).val().trim();
+    if (mac == "" || ip == "") {
+        return;
+    }
+
+    var row = $("#js-dhcp-static-lease-row").html()
+        .replace("{{ mac }}", mac)
+        .replace("{{ ip }}", ip);
+    $(".js-dhcp-static-lease-container").append(row);
+
+    $("input[name=mac]", container).val("");
+    $("input[name=ip]", container).val("");
+});
+
+$(document).on("click", ".js-remove-dhcp-static-lease", function(e) {
+    e.preventDefault();
+    $(this).parents(".js-dhcp-static-lease-row").remove();
+});
+
 function setupBtns() {
     $('#btnSummaryRefresh').click(function(){getAllInterfaces();});
 


### PR DESCRIPTION
this patch adds ui to manage static leases in the dnsmasq config. resolves #267.

<img width="712" alt="Bildschirmfoto 2019-08-01 um 18 11 30" src="https://user-images.githubusercontent.com/201135/62309832-874c7e80-b488-11e9-8b45-5b6d8e472ac6.png">

known issues:
- mac and ip addresses don't get validated
- statically assigned ip addesses should always stay outside the dhcp range (i think dhcp servers still don't exclude static addresses from their range?)