### PR TITLE
properly enable wmm by fixing a typo

### DIFF
--- a/includes/hostapd.php
+++ b/includes/hostapd.php
@@ -622,7 +622,7 @@ function SaveHostAPDConfig($wpa_array, $enc_types, $modes, $interfaces, $status)
             $config.= 'hw_mode=g'.PHP_EOL;
             $config.= 'ieee80211n=1'.PHP_EOL;
             // Enable basic Quality of service
-            $config.= 'wme_enabled=1'.PHP_EOL;
+            $config.= 'wmm_enabled=1'.PHP_EOL;
         } else {
             $config.= 'hw_mode='.$_POST['hw_mode'].PHP_EOL;
             $config.= 'ieee80211n=0'.PHP_EOL;


### PR DESCRIPTION
if `ieee80211n=1`, `wmm_enabled=1` should be configured as well
according to the docs, quote:

```
# ieee80211n: Whether IEEE 802.11n (HT) is enabled
# 0 = disabled (default)
# 1 = enabled
# Note: You will also need to enable WMM for full HT functionality.
# Note: hw_mode=g (2.4 GHz) and hw_mode=a (5 GHz) is used to specify the band.
```
> https://w1.fi/cgit/hostap/plain/hostapd/hostapd.conf