### PR TITLE
enable wifi client to connect to hidden ssid

### DIFF
--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -82,6 +82,7 @@ function DisplayWPAConfig()
                     fwrite($wpa_file, "network={".PHP_EOL);
                     fwrite($wpa_file, "\tssid=\"".$ssid."\"".PHP_EOL);
                     fwrite($wpa_file, "\tkey_mgmt=NONE".PHP_EOL);
+		    fwrite($wpa_file, "\tscan_ssid=1".PHP_EOL);
                     if (array_key_exists('priority', $network)) {
                         fwrite($wpa_file, "\tpriority=".$network['priority'].PHP_EOL);
                     }


### PR DESCRIPTION
resolves billz/raspap-webgui#345.

this adds `scan_ssid=1` to every network in `wpa_supplicant.conf`. issue is that connecting to a station may take a little longer now because this option increases scan time.
i think we should look how this works and only add a checkbox to the ui if there's problems.

according to the docs:

> For finding networks using hidden SSID, scan_ssid=1 in the network block can be used with nl80211.

and

> scan_ssid:
>	0 = do not scan this SSID with specific Probe Request frames (default)
>	1 = scan with SSID-specific Probe Request frames (this can be used to
>	    find APs that do not accept broadcast SSID or use multiple SSIDs;
>	    this will add latency to scanning, so enable this only when needed)

https://w1.fi/cgit/hostap/plain/wpa_supplicant/wpa_supplicant.conf