### PR TITLE
improved service status display

### DIFF
--- a/dist/css/custom.css
+++ b/dist/css/custom.css
@@ -49,6 +49,35 @@
         min-height:500px;
 }
 
+.service-status-running,
+.service-status-stopped {
+    background-color: #fff;
+    color: #333;
+    text-transform: uppercase;
+    line-height: inherit;
+}
+.service-status-running:before,
+.service-status-stopped:before {
+    display: inline-block;
+    height: 16px;
+    width: 16px;
+    content: "\2022";
+    font-size: 3.5em;
+    color: green;
+    line-height: 16px;
+    vertical-align: bottom;
+    margin-right: 2px;
+}
+.service-status-stopped:before {
+    color: red;
+    animation: flash 1s linear infinite;
+}
+@keyframes flash {
+  50% {
+    opacity: 0;
+  }
+}
+
 .logoutput {
     width:100%;
     height:300px;

--- a/includes/dhcp.php
+++ b/includes/dhcp.php
@@ -99,13 +99,9 @@ function DisplayDHCPConfig()
         } else {
             error_log('CSRF violation');
         }
-    } else {
-        if ($dnsmasq_state) {
-            $status->addMessage('Dnsmasq is running', 'success');
-        } else {
-            $status->addMessage('Dnsmasq is not running', 'warning');
-        }
     }
+
+    $serviceStatus = $dnsmasq_state ? "running" : "stopped";
 
     exec('cat '. RASPI_DNSMASQ_CONFIG, $return);
     $conf = ParseConfig($return);
@@ -140,7 +136,10 @@ function DisplayDHCPConfig()
   <div class="row">
   <div class="col-lg-12">
       <div class="panel panel-primary">
-      <div class="panel-heading"><i class="fa fa-exchange fa-fw"></i> <?php echo _("Configure DHCP"); ?></div>
+      <div class="panel-heading">
+        <i class="fa fa-exchange fa-fw"></i> <?php echo _("Configure DHCP"); ?>
+        <span class="label pull-right service-status-<?php echo $serviceStatus ?>">dnsmasq <?php echo _($serviceStatus) ?></span>
+      </div>
         <!-- /.panel-heading -->
         <div class="panel-body">
         <p><?php $status->showMessages(); ?></p>

--- a/includes/hostapd.php
+++ b/includes/hostapd.php
@@ -51,11 +51,7 @@ function DisplayHostAPDConfig()
     exec('cat '. RASPI_HOSTAPD_CONFIG, $hostapdconfig);
     exec('pidof hostapd | wc -l', $hostapdstatus);
 
-    if ($hostapdstatus[0] == 0) {
-        $status->addMessage('HostAPD is not running', 'warning');
-    } else {
-        $status->addMessage('HostAPD is running', 'success');
-    }
+    $serviceStatus = $hostapdstatus[0] == 0 ? "stopped" : "running";
 
     foreach ($hostapdconfig as $hostapdconfigline) {
         if (strlen($hostapdconfigline) === 0) {
@@ -72,7 +68,10 @@ function DisplayHostAPDConfig()
   <div class="row">
     <div class="col-lg-12">
       <div class="panel panel-primary">
-        <div class="panel-heading"><i class="fa fa-dot-circle-o fa-fw"></i> <?php echo _("Configure hotspot"); ?></div>
+        <div class="panel-heading">
+            <i class="fa fa-dot-circle-o fa-fw"></i> <?php echo _("Configure hotspot"); ?>
+            <span class="label pull-right service-status-<?php echo $serviceStatus ?>">hostapd <?php echo _($serviceStatus) ?></span>
+        </div>
         <!-- /.panel-heading -->
         <div class="panel-body">
       <p><?php $status->showMessages(); ?></p>


### PR DESCRIPTION
puts the service status into the panel header as a nice label.
it blinks if the service is not running ;)

| **before**  | ![before](https://user-images.githubusercontent.com/201135/62400081-4d5da400-b57e-11e9-9c1a-fa1aa2dff626.png) |
|--------|---|
| **after** | ![running](https://user-images.githubusercontent.com/201135/62400082-4df63a80-b57e-11e9-930f-e2410779e16d.png)<br>![stopped](https://user-images.githubusercontent.com/201135/62400083-4df63a80-b57e-11e9-96a3-c8ffd685d7b8.gif) |