### PR TITLE
fix csrf verification

### DIFF
--- a/ajax/bandwidth/get_bandwidth.php
+++ b/ajax/bandwidth/get_bandwidth.php
@@ -1,6 +1,6 @@
 <?php
 
-require('includes/csrf.php');
+require('../../includes/csrf.php');
 
 require_once '../../includes/config.php';
 require_once RASPI_CONFIG.'/raspap.php';

--- a/ajax/bandwidth/get_bandwidth_hourly.php
+++ b/ajax/bandwidth/get_bandwidth_hourly.php
@@ -1,6 +1,6 @@
 <?php 
 
-require('includes/csrf.php');
+require('../../includes/csrf.php');
 
 if (filter_input(INPUT_GET, 'tu') == 'h') {
 

--- a/ajax/networking/gen_int_config.php
+++ b/ajax/networking/gen_int_config.php
@@ -1,6 +1,6 @@
 <?php
 
-require('includes/csrf.php');
+require('../../includes/csrf.php');
 
 include_once('../../includes/config.php');
 include_once('../../includes/functions.php');

--- a/ajax/networking/get_all_interfaces.php
+++ b/ajax/networking/get_all_interfaces.php
@@ -1,6 +1,6 @@
 <?php
 
-    require('includes/csrf.php');
+    require('../../includes/csrf.php');
 
     exec("ls /sys/class/net | grep -v lo", $interfaces);
     echo json_encode($interfaces);

--- a/ajax/networking/get_int_config.php
+++ b/ajax/networking/get_int_config.php
@@ -1,6 +1,6 @@
 <?php
 
-require('includes/csrf.php');
+require('../../includes/csrf.php');
 
 include_once('../../includes/config.php');
 include_once('../../includes/functions.php');

--- a/ajax/networking/get_ip_summary.php
+++ b/ajax/networking/get_ip_summary.php
@@ -1,6 +1,6 @@
 <?php
 
-require('includes/csrf.php');
+require('../../includes/csrf.php');
 
 include_once('../../includes/functions.php');
 

--- a/ajax/networking/save_int_config.php
+++ b/ajax/networking/save_int_config.php
@@ -1,6 +1,6 @@
 <?php
 
-    require('includes/csrf.php');
+    require('../../includes/csrf.php');
 
     include_once('../../includes/config.php');
     include_once('../../includes/functions.php');

--- a/includes/csrf.php
+++ b/includes/csrf.php
@@ -1,7 +1,7 @@
 <?php
 
-include_once('includes/functions.php');
-include_once('includes/session.php');
+include_once('functions.php');
+include_once('session.php');
 
 if (csrfValidateRequest() && !CSRFValidate()) {
   handleInvalidCSRFToken();

--- a/includes/csrf.php
+++ b/includes/csrf.php
@@ -6,6 +6,3 @@ include_once('session.php');
 if (csrfValidateRequest() && !CSRFValidate()) {
   handleInvalidCSRFToken();
 }
-
-ensureCSRFSessionToken();
-header('X-CSRF-Token', $_SESSION['csrf_token']);

--- a/index.php
+++ b/index.php
@@ -19,6 +19,7 @@
  */
 
 require('includes/csrf.php');
+ensureCSRFSessionToken();
 
 include_once('includes/config.php');
 include_once(RASPI_CONFIG.'/raspap.php');

--- a/js/custom.js
+++ b/js/custom.js
@@ -167,14 +167,6 @@ function setCSRFTokenHeader(event, xhr, settings) {
     }
 }
 
-function updateCSRFTokens(event, xhr, settings) {
-    var newToken = xhr.getResponseHeader("X-CSRF-Token");
-    if (newToken) {
-        $('meta[name=csrf_token]').attr('content', newToken);
-        $('[name=csrf_token]:input').attr('value', newToken);
-    }
-}
-
 function contentLoaded() {
     pageCurrent = window.location.href.split("?")[1].split("=")[1];
     pageCurrent = pageCurrent.replace("#","");
@@ -190,5 +182,4 @@ function contentLoaded() {
 
 $(document)
     .ajaxSend(setCSRFTokenHeader)
-    .ajaxComplete(updateCSRFTokens)
     .ready(contentLoaded);


### PR DESCRIPTION
this fixes the mess i made in #356.

- i called `require()` and `include_once()` with wrong paths
- regenerating the csrf token on every request leads to race-conditions with xhr
- this patch makes everything work and the logic more simple by only generating a csrf token when index.php loads

please test my crap.