### PR TITLE
fix csrf token xhr race condition

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -59,7 +59,9 @@ function safefilerewrite($fileName, $dataToSave)
 */
 function ensureCSRFSessionToken()
 {
-    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
 }
 
 /**


### PR DESCRIPTION
fixes #377. the initial ajax-loading of wifi stations regenerated the token in the session so any future form submission (e.g., connecting to a network) would fail guaranteed. bummer. will look into a more solid implementation.