### PR TITLE
fix hostapd log permissions

### DIFF
--- a/installers/enablelog.sh
+++ b/installers/enablelog.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
 /bin/sed -i 's|#DAEMON_OPTS=""|DAEMON_OPTS=" -f /tmp/hostapd.log"|' /etc/default/hostapd
+touch /tmp/hostapd.log
+chmod o+r /tmp/hostapd.log


### PR DESCRIPTION
hostapd runs as root and it creates its logfile with 0640 file permissions.

    -rw-r-----  1 root     root     63727 Aug 20 21:10 hostapd.log

raspap reads that file without elevated privileges which is why the logfile output in the ui is always empty.

this pr fixes it by

1. creating the file ourselves in `enablelog.sh`
2. setting its permissions to 0644 (`chmod o+r`)  

        -rw-r--r--  1 root     root     63727 Aug 20 21:10 hostapd.log