### PR TITLE
fix panel heading style in network config

### DIFF
--- a/includes/networking.php
+++ b/includes/networking.php
@@ -21,7 +21,7 @@ function DisplayNetworkingConfig()
 <div class="row">
     <div class="col-lg-12">
        <div class="panel panel-primary">
-          <div class="panel panel-heading">
+          <div class="panel-heading">
       <i class="fa fa-sitemap fa-fw"></i> <?php echo _("Configure networking"); ?></div>
           <div class="panel-body">
             <div id="msgNetworking"></div>


### PR DESCRIPTION
| before | after |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/201135/63382198-837e8e80-c39a-11e9-892d-65529b3418c5.png) | ![after](https://user-images.githubusercontent.com/201135/63382199-837e8e80-c39a-11e9-9d67-c107d0ee0799.png) |
