### PR TITLE
[RFC] Add custom configuration parameter handling layer

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -19,6 +19,7 @@ define('RASPI_WPA_CTRL_INTERFACE', '/var/run/wpa_supplicant');
 define('RASPI_OPENVPN_CLIENT_CONFIG', '/etc/openvpn/client.conf');
 define('RASPI_OPENVPN_SERVER_CONFIG', '/etc/openvpn/server.conf');
 define('RASPI_TORPROXY_CONFIG', '/etc/tor/torrc');
+define('RASPI_CUSTOM_CONFIG', '/etc/raspap/custom.ini');
 
 // Optional services, set to true to enable.
 define('RASPI_WIFICLIENT_ENABLED', true);
@@ -30,7 +31,18 @@ define('RASPI_TORPROXY_ENABLED', false);
 define('RASPI_CONFAUTH_ENABLED', true);
 define('RASPI_CHANGETHEME_ENABLED', true);
 define('RASPI_VNSTAT_ENABLED', true);
+define('RASPI_CUSTOM_ENABLED', true);
 
 // Locale settings
 define('LOCALE_ROOT', 'locale');
 define('LOCALE_DOMAIN', 'messages');
+
+
+// Custom Configuration Parameters
+define('RASPI_CUSTOM_FIELDS', array(
+    'Network Proxy Configuration' => array(
+        'host' => 'Network Proxy Host',
+        'port' => 'Network Proxy Port', 
+        'user' => 'Network Proxy User', 
+        'pass' => 'Network Proxy Pass'),
+));

--- a/includes/custom.php
+++ b/includes/custom.php
@@ -1,0 +1,58 @@
+<?php
+
+include_once('includes/config.php');
+include_once('includes/functions.php');
+include_once('includes/status_messages.php');
+
+
+function DisplayCustomConfig()
+{
+    $status = new StatusMessages();
+    $data = parse_ini_file(RASPI_CUSTOM_CONFIG, true);
+    
+    foreach (RASPI_CUSTOM_FIELDS as $title => $params){
+        $titlecode = str_replace(' ', '', $title);
+        if (isset($_POST[$titlecode])) {
+            foreach($params as $key => $desc){
+                $data[$titlecode][$key] = $_POST[$key];
+            }
+            write_php_ini($data, RASPI_CUSTOM_CONFIG);
+        }
+    }
+    
+    foreach (RASPI_CUSTOM_FIELDS as $title => $params)
+    {
+        $titlecode = str_replace(' ', '', $title);
+        ?>
+
+<div class="row">
+    <div class="col-lg-12">
+      <div class="panel panel-primary">
+        <div class="panel-heading"><i class="fa fa-lock fa-fw"></i><?php echo _("$title"); ?></div>
+        <div class="panel-body">
+          <p><?php $status->showMessages(); ?></p>
+          <form role="form" action="?page=custom_conf" method="POST">
+            <?php echo CSRFTokenFieldTag() ?>
+
+            <?php foreach ($params as $key => $desc){ ?>
+                <div class="row">
+                <div class="form-group col-md-4">
+                    <label for="$key"><?php echo _($desc); ?></label>
+                    <input type="text" class="form-control" name="<?php echo _($key); ?>" value="<?php echo _($data[$titlecode][$key]); ?>"/>
+                </div>
+                </div>
+            <?php } ?>
+
+        <input type="submit" class="btn btn-outline btn-primary" name="<?php echo _($titlecode); ?>" value="<?php echo _("Save settings"); ?>" />
+        </form>
+        </div><!-- /.panel-body -->
+      </div><!-- /.panel-default -->
+    </div><!-- /.col-lg-12 -->
+  </div><!-- /.row -->
+
+<?php
+}
+}
+?>
+s
+          

--- a/index.php
+++ b/index.php
@@ -33,6 +33,7 @@ include_once('includes/hostapd.php');
 include_once('includes/system.php');
 include_once('includes/configure_client.php');
 include_once('includes/networking.php');
+include_once('includes/custom.php');
 include_once('includes/themes.php');
 include_once('includes/data_usage.php');
 include_once('includes/about.php');
@@ -154,6 +155,11 @@ $theme_url = 'dist/css/'.htmlspecialchars($theme, ENT_QUOTES);
                  <a href="index.php?page=torproxy_conf"><i class="fa fa-eye-slash fa-fw"></i> <?php echo _("Configure TOR proxy"); ?></a>
               </li>
                 <?php endif; ?>
+                <?php if (RASPI_CUSTOM_ENABLED) : ?>
+              <li>
+                <a href="index.php?page=custom_conf"><i class="fa fa-wrench fa-fw"></i> <?php echo _("Configure Application"); ?></a>
+              </li>
+                <?php endif; ?>
                 <?php if (RASPI_CONFAUTH_ENABLED) : ?>
               <li>
                 <a href="index.php?page=auth_conf"><i class="fa fa-lock fa-fw"></i> <?php echo _("Configure Auth"); ?></a>
@@ -215,6 +221,9 @@ $theme_url = 'dist/css/'.htmlspecialchars($theme, ENT_QUOTES);
                 break;
             case "torproxy_conf":
                 DisplayTorProxyConfig();
+                break;
+            case "custom_conf":
+                DisplayCustomConfig();
                 break;
             case "auth_conf":
                 DisplayAuthConfig($config['admin_user'], $config['admin_pass']);

--- a/index.php
+++ b/index.php
@@ -157,7 +157,7 @@ $theme_url = 'dist/css/'.htmlspecialchars($theme, ENT_QUOTES);
                 <?php endif; ?>
                 <?php if (RASPI_CUSTOM_ENABLED) : ?>
               <li>
-                <a href="index.php?page=custom_conf"><i class="fa fa-wrench fa-fw"></i> <?php echo _("Configure Application"); ?></a>
+                <a href="index.php?page=custom_conf"><i class="fa fa-wrench fa-fw"></i> <?php echo _("Additional Configuration"); ?></a>
               </li>
                 <?php endif; ?>
                 <?php if (RASPI_CONFAUTH_ENABLED) : ?>


### PR DESCRIPTION
This is a quick example of what I suggest in #381 and is put here for comment. At the very least, some minor cleanup will be needed before merge. In practice, I expect many other changes will be needed to make it safe.

![image](https://user-images.githubusercontent.com/226507/63478139-21ab4b00-c4a6-11e9-8200-fb11bb879a41.png)

The goal of this PR is to provide the "Additional Configuration" tab, which has only user defined fields. 

The fields are defined in includes/config.php. A more appropriate location for these definitions may be found if editing includes/config.php is typically not user editable. The following are the new lines added to the config.php, for an example use case for providing proxy configuration options : 

```
define('RASPI_CUSTOM_CONFIG', '/etc/raspap/custom.ini');
define('RASPI_CUSTOM_ENABLED', true);  // Default should be set to false

// Custom Configuration Parameters
define('RASPI_CUSTOM_FIELDS', array(
    'Network Proxy Configuration' => array(
        'host' => 'Network Proxy Host',
        'port' => 'Network Proxy Port', 
        'user' => 'Network Proxy User', 
        'pass' => 'Network Proxy Pass'),
));
```

Of these lines, RASPI_CUSTOM_FIELDS would be empty in the default case. The user would be able to add any number of configuration blocks to these fields as shown for one block above. 

These configuration parameters are saved to the ini file specified by RASPI_CUSTOM_CONFIG, which must also be created by the user and given appropriate permissions (tested to work with chmod www-data:www-data).

```
$ cat /etc/raspap/custom.ini 
[NetworkProxyConfiguration]
host = test
port = adfkasjf;
user = 
pass = 
```
It will be left to the user of raspap to do with the custom.ini and its content what they want. In this example, for instance, proxy settings are not actually propagated anywhere by raspap. It will be upto the user application to read this configuration file, just as it was the user's decision to use this approach.

Assuming the general idea is acceptable, the following are left to be done or atleast considered : 

1. The default configuration should be changed to disable this and RASPI_CUSTOM_FIELDS should probably be empty by default.
2. Status messages are currently not generated, and should be.
3. ~~My logs are currently full of `Undefined index: HTTP_X_CSRF_TOKEN` from this page, and I'm not sure why.~~  
4. Some means to specify validation per field may be considered. A starting point could be to add another layer of array, for ex. `'Network Proxy Host'` would become `array('desc' =>'Network Proxy Host', 'validator' => $some_func)`.
5. The only translatable string added here is "Additional Configuration". The rest of the strings are all user generated. A means to allow the user to add their own supplemental translation files might be useful. For a number of users like me not targeting multiple languages, though, the user generated strings themselves can be in their desired language.
