### PR TITLE
Update dhcpcd.conf dns safe

### DIFF
--- a/config/dhcpcd.conf
+++ b/config/dhcpcd.conf
@@ -14,7 +14,7 @@ nohook lookup-hostname
 interface wlan0
 static ip_address=10.3.141.1/24
 static routers=10.3.141.1
-static domain_name_server=1.1.1.1 8.8.8.8
+static domain_name_server=9.9.9.9 1.1.1.1
 
 # RaspAP uap0 configuration
 interface uap0


### PR DESCRIPTION
Quad9 provides DNSSEC validation on our primary resolvers.
in addition Quad9 validate DNSSEC on our EDNS enabled service.
Quad9 does not and never will share any of its data with marketers, nor will it use this data for demographic analysis.
This means that for domains that implement DNSSEC security, the Quad9 system will cryptographically ensure that the response provided matches the intended response of the domain operator. In the event of a cryptographic failure, our system will not return an answer at all. This ensures protection against domain spoofing or other attacks that attempt to provide false data. Learn more about DNSSEC here: https://www.icann.org/resources/pages/dnssec-qaa-2014-01-29-en