### PR TITLE
add conf-dir option to dnsmasq.conf

### DIFF
--- a/includes/dhcp.php
+++ b/includes/dhcp.php
@@ -67,6 +67,8 @@ function DisplayDHCPConfig()
                     $config .= PHP_EOL;
                 }
 
+                $config .= "conf-dir=/etc/dnsmasq.d".PHP_EOL;
+
                 file_put_contents("/tmp/dnsmasqdata", $config);
                 system('sudo cp /tmp/dnsmasqdata '.RASPI_DNSMASQ_CONFIG, $return);
             } else {

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -233,6 +233,8 @@ function default_configuration() {
     sudo cp $webroot_dir/config/dnsmasq.conf /etc/dnsmasq.conf || install_error "Unable to move dnsmasq configuration file"
     sudo cp $webroot_dir/config/dhcpcd.conf /etc/dhcpcd.conf || install_error "Unable to move dhcpcd configuration file"
 
+    [ -d /etc/dnsmasq.d ] || sudo mkdir /etc/dnsmasq.d
+
     if [ ! -f "$webroot_dir/includes/config.php" ]; then
         sudo cp "$webroot_dir/config/config.php" "$webroot_dir/includes/config.php"
     fi


### PR DESCRIPTION
this allows custom configuration stored in files in /etc/dnsmasq.d. raspap does not touch them and they'll always be loaded.

also creates /etc/dnsmasq.d if it doesn't exist.

closes #403.