### PR TITLE
show wifi qr code in "hotspot > security" section

### DIFF
--- a/app/img/wifi-qr-code.php
+++ b/app/img/wifi-qr-code.php
@@ -1,0 +1,49 @@
+<?php
+
+require_once '../../includes/config.php';
+require_once '../../includes/defaults.php';
+
+function qr_encode($str)
+{
+    return preg_replace('/(?<!\\\)([\":;,])/', '\\\\\1', $str);
+}
+
+$hostapd = parse_ini_file(RASPI_HOSTAPD_CONFIG, false, INI_SCANNER_RAW);
+
+// assume wpa encryption and get the passphrase
+$type = "WPA";
+$password = isset($hostapd['wpa_psk']) ? $hostapd['wpa_psk'] : $hostapd['wpa_passphrase'];
+
+// use wep if configured
+$wep_default_key = intval($hostapd['wep_default_key']);
+$wep_key = 'wep_key' . $wep_default_key;
+if (array_key_exists($wep_key, $hostapd)) {
+    $type = "WEP";
+    $password = $hostapd[$wep_key];
+}
+
+// if password is still empty, assume nopass
+if (empty($password)) {
+    $type = "nopass";
+}
+
+$ssid = $hostapd['ssid'];
+$hidden = intval($hostapd['ignore_broadcast_ssid']) != 0 ? "H:true" : "";
+
+$ssid = qr_encode($ssid);
+$password = qr_encode($password);
+
+$data = "WIFI:S:$ssid;T:$type;P:$password;$hidden;";
+$command = "qrencode -t svg -m 0 -o - " . escapeshellarg($data);
+$svg = shell_exec($command);
+
+$config_mtime  = filemtime(RASPI_HOSTAPD_CONFIG);
+$last_modified = gmdate('D, d M Y H:i:s ', $config_mtime) . 'GMT';
+$content_length = strlen($svg);
+
+header("Content-Type: image/svg+xml");
+header("Content-Length: $content_length");
+header("Last-Modified: $last_modified");
+header("X-QR-Code-Content: $data");
+echo shell_exec($command);
+

--- a/app/img/wifi-qr-code.php
+++ b/app/img/wifi-qr-code.php
@@ -2,6 +2,7 @@
 
 require_once '../../includes/config.php';
 require_once '../../includes/defaults.php';
+require_once '../../includes/functions.php';
 
 function qr_encode($str)
 {
@@ -34,7 +35,7 @@ $ssid = qr_encode($ssid);
 $password = qr_encode($password);
 
 $data = "WIFI:S:$ssid;T:$type;P:$password;$hidden;";
-$command = "qrencode -t svg -m 0 -o - " . escapeshellarg($data);
+$command = "qrencode -t svg -m 0 -o - " . mb_escapeshellarg($data);
 $svg = shell_exec($command);
 
 $config_mtime  = filemtime(RASPI_HOSTAPD_CONFIG);

--- a/app/img/wifi-qr-code.php
+++ b/app/img/wifi-qr-code.php
@@ -40,11 +40,13 @@ $svg = shell_exec($command);
 
 $config_mtime  = filemtime(RASPI_HOSTAPD_CONFIG);
 $last_modified = gmdate('D, d M Y H:i:s ', $config_mtime) . 'GMT';
+$etag = hash('sha256', $data);
 $content_length = strlen($svg);
 
 header("Content-Type: image/svg+xml");
 header("Content-Length: $content_length");
 header("Last-Modified: $last_modified");
+header("ETag: \"$etag\"");
 header("X-QR-Code-Content: $data");
 echo shell_exec($command);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -332,3 +332,17 @@ function cache($key, $callback)
         return $data;
     }
 }
+
+// insspired by
+// http://markushedlund.com/dev/php-escapeshellarg-with-unicodeutf-8-support
+function mb_escapeshellarg($arg)
+{
+    $isWindows = strtolower(substr(PHP_OS, 0, 3)) === 'win';
+    if ($isWindows) {
+        $escaped_arg = str_replace(array('"', '%'), '', $arg);
+    } else {
+        $escaped_arg = str_replace("'", "'\\''", $arg);
+    }
+    return "\"$escaped_arg\"";
+}
+

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -63,7 +63,7 @@ function config_installation() {
 # Runs a system software update to make sure we're using all fresh packages
 function install_dependencies() {
     install_log "Installing required packages"
-    sudo apt-get install $apt_option lighttpd $php_package git hostapd dnsmasq vnstat || install_error "Unable to install dependencies"
+    sudo apt-get install $apt_option lighttpd $php_package git hostapd dnsmasq vnstat qrencode || install_error "Unable to install dependencies"
 }
 
 # Enables PHP for lighttpd and restarts service for settings to take effect

--- a/templates/hostapd.php
+++ b/templates/hostapd.php
@@ -82,21 +82,25 @@
           <div class="tab-pane fade" id="security">
             <h4 class="mt-3"><?php echo _("Security settings"); ?></h4>
             <div class="row">
-              <div class="form-group col-md-6">
-                <label for="cbxwpa"><?php echo _("Security type"); ?></label>
-                <?php SelectorOptions('wpa', $arrSecurity, $arrConfig['wpa'], 'cbxwpa'); ?>
+              <div class="col-md-6">
+                <div class="form-group">
+                  <label for="cbxwpa"><?php echo _("Security type"); ?></label>
+                  <?php SelectorOptions('wpa', $arrSecurity, $arrConfig['wpa'], 'cbxwpa'); ?>
+                </div>
+                <div class="form-group">
+                  <label for="cbxwpapairwise"><?php echo _("Encryption Type"); ?></label>
+                  <?php SelectorOptions('wpa_pairwise', $arrEncType, $arrConfig['wpa_pairwise'], 'cbxwpapairwise'); ?>
+                </div>
+                <div class="form-group">
+                  <label for="txtwpapassphrase"><?php echo _("PSK"); ?></label>
+                  <input type="text" class="form-control" id="txtwpapassphrase" name="wpa_passphrase" value="<?php echo htmlspecialchars($arrConfig['wpa_passphrase'], ENT_QUOTES); ?>" />
+                </div>
               </div>
-            </div>
-            <div class="row">
-              <div class="form-group col-md-6">
-                <label for="cbxwpapairwise"><?php echo _("Encryption Type"); ?></label>
-                <?php SelectorOptions('wpa_pairwise', $arrEncType, $arrConfig['wpa_pairwise'], 'cbxwpapairwise'); ?>
-              </div>
-            </div>
-            <div class="row">
-              <div class="form-group col-md-6">
-                <label for="txtwpapassphrase"><?php echo _("PSK"); ?></label>
-                <input type="text" class="form-control" id="txtwpapassphrase" name="wpa_passphrase" value="<?php echo htmlspecialchars($arrConfig['wpa_passphrase'], ENT_QUOTES); ?>" />
+              <div class="col-md-6">
+                <figure class="figure">
+                  <img src="/app/img/wifi-qr-code.php" class="figure-img img-fluid" alt="RaspAP Wifi QR code" style="width:100%;">
+                  <figcaption class="figure-caption"><?php echo _("Scan this QR code with your phone to connect to this RaspAP."); ?></figcaption>
+                </figure>
               </div>
             </div>
           </div>


### PR DESCRIPTION
resolves #469.

- generates qr code by calling `qrencode` command directly
- uses svg format
- wrapped svg in a bootstrap `figure` with caption for instructions
- calls qrencode in realtime, reading current hostapd config
- tries to escape password string according to [instructions over there](https://github.com/zxing/zxing/wiki/Barcode-Contents#wi-fi-network-config-android-ios-11)

let me know.

![Bildschirmfoto 2020-02-26 um 18 56 32](https://user-images.githubusercontent.com/201135/75373037-ca10f080-58c9-11ea-91b5-21bcaa2b4314.png)
![Bildschirmfoto 2020-02-26 um 18 56 15](https://user-images.githubusercontent.com/201135/75373040-caa98700-58c9-11ea-8090-dd50eb6c6a55.png)