### PR TITLE
remove redundant wording

### DIFF
--- a/index.php
+++ b/index.php
@@ -129,37 +129,37 @@ if ($_COOKIE['sidebarToggled'] == 'true' ) {
         </li>
         <?php if (RASPI_WIFICLIENT_ENABLED) : ?>
         <li class="nav-item">
-          <a class="nav-link" href="index.php?page=wpa_conf"><i class="fas fa-wifi fa-fw mr-2"></i><span class="nav-label"><?php echo _("Configure WiFi client"); ?></span></a>
+          <a class="nav-link" href="index.php?page=wpa_conf"><i class="fas fa-wifi fa-fw mr-2"></i><span class="nav-label"><?php echo _("WiFi client"); ?></span></a>
         </li>
         <?php endif; ?>
           <?php if (RASPI_HOTSPOT_ENABLED) : ?>
         <li class="nav-item">
-          <a class="nav-link" href="index.php?page=hostapd_conf"><i class="far fa-dot-circle fa-fw mr-2"></i><span class="nav-label"><?php echo _("Configure hotspot"); ?></a>
+          <a class="nav-link" href="index.php?page=hostapd_conf"><i class="far fa-dot-circle fa-fw mr-2"></i><span class="nav-label"><?php echo _("Hotspot"); ?></a>
         </li>
           <?php endif; ?>
           <?php if (RASPI_NETWORK_ENABLED) : ?>
         <li class="nav-item">
-           <a class="nav-link" href="index.php?page=network_conf"><i class="fas fa-network-wired fa-fw mr-2"></i><span class="nav-label"><?php echo _("Configure networking"); ?></a>
+           <a class="nav-link" href="index.php?page=network_conf"><i class="fas fa-network-wired fa-fw mr-2"></i><span class="nav-label"><?php echo _("Networking"); ?></a>
         </li> 
           <?php endif; ?>
           <?php if (RASPI_DHCP_ENABLED) : ?>
         <li class="nav-item">
-          <a class="nav-link" href="index.php?page=dhcpd_conf"><i class="fas fa-exchange-alt fa-fw mr-2"></i><span class="nav-label"><?php echo _("Configure DHCP Server"); ?></a>
+          <a class="nav-link" href="index.php?page=dhcpd_conf"><i class="fas fa-exchange-alt fa-fw mr-2"></i><span class="nav-label"><?php echo _("DHCP Server"); ?></a>
         </li>
           <?php endif; ?>
           <?php if (RASPI_OPENVPN_ENABLED) : ?>
         <li class="nav-item">
-          <a class="nav-link" href="index.php?page=openvpn_conf"><i class="fas fa-key fa-fw mr-2"></i><span class="nav-label"><?php echo _("Configure OpenVPN"); ?></a>
+          <a class="nav-link" href="index.php?page=openvpn_conf"><i class="fas fa-key fa-fw mr-2"></i><span class="nav-label"><?php echo _("OpenVPN"); ?></a>
         </li>
           <?php endif; ?>
           <?php if (RASPI_TORPROXY_ENABLED) : ?>
         <li class="nav-item">
-           <a class="nav-link" href="index.php?page=torproxy_conf"><i class="fas fa-eye-slash fa-fw mr-2"></i><span class="nav-label"><?php echo _("Configure TOR proxy"); ?></a>
+           <a class="nav-link" href="index.php?page=torproxy_conf"><i class="fas fa-eye-slash fa-fw mr-2"></i><span class="nav-label"><?php echo _("TOR proxy"); ?></a>
         </li>
           <?php endif; ?>
           <?php if (RASPI_CONFAUTH_ENABLED) : ?>
         <li class="nav-item">
-        <a class="nav-link" href="index.php?page=auth_conf"><i class="fas fa-user-lock fa-fw mr-2"></i><span class="nav-label"><?php echo _("Configure Auth"); ?></a>
+        <a class="nav-link" href="index.php?page=auth_conf"><i class="fas fa-user-lock fa-fw mr-2"></i><span class="nav-label"><?php echo _("Auth"); ?></a>
         </li>
           <?php endif; ?>
           <?php if (RASPI_CHANGETHEME_ENABLED) : ?>

--- a/index.php
+++ b/index.php
@@ -159,7 +159,7 @@ if ($_COOKIE['sidebarToggled'] == 'true' ) {
           <?php endif; ?>
           <?php if (RASPI_CONFAUTH_ENABLED) : ?>
         <li class="nav-item">
-        <a class="nav-link" href="index.php?page=auth_conf"><i class="fas fa-user-lock fa-fw mr-2"></i><span class="nav-label"><?php echo _("Auth"); ?></a>
+        <a class="nav-link" href="index.php?page=auth_conf"><i class="fas fa-user-lock fa-fw mr-2"></i><span class="nav-label"><?php echo _("Authentication"); ?></a>
         </li>
           <?php endif; ?>
           <?php if (RASPI_CHANGETHEME_ENABLED) : ?>

--- a/locale/cs_CZ/LC_MESSAGES/messages.po
+++ b/locale/cs_CZ/LC_MESSAGES/messages.po
@@ -31,25 +31,25 @@ msgstr "RaspAP Wifi Portál"
 msgid "Dashboard"
 msgstr "Přehled"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "Nastavení WiFi klienta"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "Nastavení hotspot(u)"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "Nastavení sítě"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "Nastavení DHCP Serveru"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "Nastavení OpenVPN"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "Nastavení TOR proxy"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "Nastavení Autentifikace"
 
 msgid "Change Theme"

--- a/locale/cs_CZ/LC_MESSAGES/messages.po
+++ b/locale/cs_CZ/LC_MESSAGES/messages.po
@@ -49,7 +49,7 @@ msgstr "Nastavení OpenVPN"
 msgid "TOR proxy"
 msgstr "Nastavení TOR proxy"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "Nastavení Autentifikace"
 
 msgid "Change Theme"

--- a/locale/de_DE/LC_MESSAGES/messages.po
+++ b/locale/de_DE/LC_MESSAGES/messages.po
@@ -31,25 +31,25 @@ msgstr "RaspAP WLAN Portal"
 msgid "Dashboard"
 msgstr "Übersicht"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "WLAN Client einrichten"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "Hotspot einrichten"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "Netzwerk einrichten"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "DHCP Server einrichten"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "OpenVPN einrichten"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "TOR Proxy einrichten"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "Authentifizierung einrichten"
 
 msgid "Change Theme"

--- a/locale/de_DE/LC_MESSAGES/messages.po
+++ b/locale/de_DE/LC_MESSAGES/messages.po
@@ -49,7 +49,7 @@ msgstr "OpenVPN einrichten"
 msgid "TOR proxy"
 msgstr "TOR Proxy einrichten"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "Authentifizierung einrichten"
 
 msgid "Change Theme"

--- a/locale/el_GR/LC_MESSAGES/messages.po
+++ b/locale/el_GR/LC_MESSAGES/messages.po
@@ -48,7 +48,7 @@ msgstr "Διαμόρφωση OpenVPN"
 msgid "TOR proxy" 
 msgstr "Διαμόρφωση μεσολαβητή TOR" 
 
-msgid "Auth" 
+msgid "Authentication" 
 msgstr "Διαμόρφωση Auth" 
 
 msgid "Change Theme" 

--- a/locale/el_GR/LC_MESSAGES/messages.po
+++ b/locale/el_GR/LC_MESSAGES/messages.po
@@ -30,25 +30,25 @@ msgstr "Πύλη RaspAP WiFi"
 msgid "Dashboard" 
 msgstr "Πίνακας" 
 
-msgid "Configure WiFi client" 
+msgid "WiFi client" 
 msgstr "Διαμόρφωση WiFi client" 
 
-msgid "Configure hotspot" 
+msgid "Hotspot" 
 msgstr "Διαμόρφωση hotspot" 
 
-msgid "Configure networking" 
+msgid "Networking" 
 msgstr "Διαμόρφωση δικτύωσης" 
 
-msgid "Configure DHCP Server" 
+msgid "DHCP Server" 
 msgstr "Διαμόρφωση διακομιστή DHCP" 
 
-msgid "Configure OpenVPN" 
+msgid "OpenVPN" 
 msgstr "Διαμόρφωση OpenVPN" 
 
-msgid "Configure TOR proxy" 
+msgid "TOR proxy" 
 msgstr "Διαμόρφωση μεσολαβητή TOR" 
 
-msgid "Configure Auth" 
+msgid "Auth" 
 msgstr "Διαμόρφωση Auth" 
 
 msgid "Change Theme" 

--- a/locale/en_US/LC_MESSAGES/messages.po
+++ b/locale/en_US/LC_MESSAGES/messages.po
@@ -49,8 +49,8 @@ msgstr "OpenVPN"
 msgid "TOR proxy"
 msgstr "TOR proxy"
 
-msgid "Auth"
-msgstr "Auth"
+msgid "Authentication"
+msgstr "Authentication"
 
 msgid "Change Theme"
 msgstr "Change Theme"

--- a/locale/en_US/LC_MESSAGES/messages.po
+++ b/locale/en_US/LC_MESSAGES/messages.po
@@ -31,26 +31,26 @@ msgstr "RaspAP Wifi Portal"
 msgid "Dashboard"
 msgstr "Dashboard"
 
-msgid "Configure WiFi client"
-msgstr "Configure WiFi client"
+msgid "WiFi client"
+msgstr "WiFi client"
 
-msgid "Configure hotspot"
-msgstr "Configure hotspot"
+msgid "Hotspot"
+msgstr "Hotspot"
 
-msgid "Configure networking"
-msgstr "Configure networking"
+msgid "Networking"
+msgstr "Networking"
 
-msgid "Configure DHCP Server"
-msgstr "Configure DHCP Server"
+msgid "DHCP Server"
+msgstr "DHCP Server"
 
-msgid "Configure OpenVPN"
-msgstr "Configure OpenVPN"
+msgid "OpenVPN"
+msgstr "OpenVPN"
 
-msgid "Configure TOR proxy"
-msgstr "Configure TOR proxy"
+msgid "TOR proxy"
+msgstr "TOR proxy"
 
-msgid "Configure Auth"
-msgstr "Configure Auth"
+msgid "Auth"
+msgstr "Auth"
 
 msgid "Change Theme"
 msgstr "Change Theme"

--- a/locale/es_MX/LC_MESSAGES/messages.po
+++ b/locale/es_MX/LC_MESSAGES/messages.po
@@ -49,7 +49,7 @@ msgstr "Configurar OpenVPN"
 msgid "TOR proxy"
 msgstr "Configurar TOR proxy"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "Configurar autentificacion"
 
 msgid "Change Theme"

--- a/locale/es_MX/LC_MESSAGES/messages.po
+++ b/locale/es_MX/LC_MESSAGES/messages.po
@@ -31,25 +31,25 @@ msgstr "Portal de RaspAP wifi"
 msgid "Dashboard"
 msgstr "Tablero"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "Configurar cliente wiFi"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "Configurar hotspot"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "Configurar red de trabajo"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "Configurar servidor DHCP"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "Configurar OpenVPN"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "Configurar TOR proxy"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "Configurar autentificacion"
 
 msgid "Change Theme"

--- a/locale/fi_FI/LC_MESSAGES/messages.po
+++ b/locale/fi_FI/LC_MESSAGES/messages.po
@@ -31,25 +31,25 @@ msgstr "RaspAP Wifi portaali"
 msgid "Dashboard"
 msgstr "Ohjauspaneeli"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "Konfiguroi WiFi asiakas"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "Konfiguroi yhteyspiste"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "Konfiguroi yhteyksia"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "Konfiguroi DHCP palvelinta"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "Konfiguroi OpenVPN"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "Konfiguroi TOR välitypalvelinta"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "Konfiguroi Auth"
 
 msgid "Change Theme"

--- a/locale/fi_FI/LC_MESSAGES/messages.po
+++ b/locale/fi_FI/LC_MESSAGES/messages.po
@@ -49,7 +49,7 @@ msgstr "Konfiguroi OpenVPN"
 msgid "TOR proxy"
 msgstr "Konfiguroi TOR välitypalvelinta"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "Konfiguroi Auth"
 
 msgid "Change Theme"

--- a/locale/fr_FR/LC_MESSAGES/messages.po
+++ b/locale/fr_FR/LC_MESSAGES/messages.po
@@ -31,25 +31,25 @@ msgstr "RaspAP Wifi Portail"
 msgid "Dashboard"
 msgstr "Tableau de bord"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "Configurer client WiFi"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "Configurer hotspot"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "Configurer réseau"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "Configurer server DHCP"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "Configurer OpenVPN"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "Configurer proxy TOR"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "Configurer Auth"
 
 msgid "Change Theme"
@@ -403,7 +403,7 @@ msgid "Maximum number of clients"
 msgstr "Nombre maximum de clients"
 
 msgid "Configures the max_num_sta option of hostapd. The default and maximum is 2007. If empty or 0, the default applies."
-msgstr "Configure l'option max_num_sta de hostapd. La valeur par défaut et maximum est 2007. Si vide ou 0, la valeur par défaut s'applique."
+msgstr "l'option max_num_sta de hostapd. La valeur par défaut et maximum est 2007. Si vide ou 0, la valeur par défaut s'applique."
 
 #: includes/networking.php
 msgid "Summary"

--- a/locale/fr_FR/LC_MESSAGES/messages.po
+++ b/locale/fr_FR/LC_MESSAGES/messages.po
@@ -49,7 +49,7 @@ msgstr "Configurer OpenVPN"
 msgid "TOR proxy"
 msgstr "Configurer proxy TOR"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "Configurer Auth"
 
 msgid "Change Theme"

--- a/locale/id_ID/LC_MESSAGES/messages.po
+++ b/locale/id_ID/LC_MESSAGES/messages.po
@@ -35,25 +35,25 @@ msgstr "Portal Wifi RaspAP"
 msgid "Dashboard"
 msgstr "Dasbor"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "Atur klien WiFi"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "Atur hotspot"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "Atur jaringan"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "Atur Server DHCP"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "Atur OpenVPN"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "Konfigurasikan proxy TOR"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "Konfigurasi Auth"
 
 msgid "Change Theme"

--- a/locale/id_ID/LC_MESSAGES/messages.po
+++ b/locale/id_ID/LC_MESSAGES/messages.po
@@ -53,7 +53,7 @@ msgstr "Atur OpenVPN"
 msgid "TOR proxy"
 msgstr "Konfigurasikan proxy TOR"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "Konfigurasi Auth"
 
 msgid "Change Theme"

--- a/locale/it_IT/LC_MESSAGES/messages.po
+++ b/locale/it_IT/LC_MESSAGES/messages.po
@@ -49,7 +49,7 @@ msgstr "Configura OpenVPN"
 msgid "TOR proxy"
 msgstr "Configura proxy TOR"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "Configura Auth"
 
 msgid "Change Theme"

--- a/locale/it_IT/LC_MESSAGES/messages.po
+++ b/locale/it_IT/LC_MESSAGES/messages.po
@@ -31,25 +31,25 @@ msgstr "RaspAP Wifi Portal"
 msgid "Dashboard"
 msgstr "Dashboard"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "Configura client WiFi"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "Configura hotspot"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "Configura rete"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "Configura server DHCP"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "Configura OpenVPN"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "Configura proxy TOR"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "Configura Auth"
 
 msgid "Change Theme"

--- a/locale/ja_JP/LC_MESSAGES/messages.po
+++ b/locale/ja_JP/LC_MESSAGES/messages.po
@@ -53,7 +53,7 @@ msgstr "OpenVPNを設定"
 msgid "TOR proxy"
 msgstr "TORプロキシを設定"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "認証を構成する"
 
 msgid "Change Theme"

--- a/locale/ja_JP/LC_MESSAGES/messages.po
+++ b/locale/ja_JP/LC_MESSAGES/messages.po
@@ -35,25 +35,25 @@ msgstr "RaspAP Wifiポータル"
 msgid "Dashboard"
 msgstr "ダッシュボード"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "WiFiクライアントを設定"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "ホットスポットを設定"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "ネットワークを設定"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "DHCPサーバーを構成"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "OpenVPNを設定"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "TORプロキシを設定"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "認証を構成する"
 
 msgid "Change Theme"

--- a/locale/ko_KR/LC_MESSAGES/messages.po
+++ b/locale/ko_KR/LC_MESSAGES/messages.po
@@ -53,7 +53,7 @@ msgstr "OpenVPN 환경설정"
 msgid "TOR proxy"
 msgstr "TOR 프록시 구성"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "Auth 구성 "
 
 msgid "Change Theme"

--- a/locale/ko_KR/LC_MESSAGES/messages.po
+++ b/locale/ko_KR/LC_MESSAGES/messages.po
@@ -35,25 +35,25 @@ msgstr "RaspAP WiFi 포탈"
 msgid "Dashboard"
 msgstr "대시보드 "
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "WiFi 클라이언트 환경설정"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "핫스팟 환경설정"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "네트워킹 환경설정"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "DHCP 서버 구성"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "OpenVPN 환경설정"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "TOR 프록시 구성"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "Auth 구성 "
 
 msgid "Change Theme"

--- a/locale/nl_NL/LC_MESSAGES/messages.po
+++ b/locale/nl_NL/LC_MESSAGES/messages.po
@@ -49,7 +49,7 @@ msgstr "Configureer OpenVPN"
 msgid "TOR proxy"
 msgstr "Configureer TOR proxy"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "Configureer autenticatie"
 
 msgid "Change Theme"

--- a/locale/nl_NL/LC_MESSAGES/messages.po
+++ b/locale/nl_NL/LC_MESSAGES/messages.po
@@ -31,25 +31,25 @@ msgstr "RaspAP Wi-fi portaal"
 msgid "Dashboard"
 msgstr "Dashboard"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "Configureer WiFi apparaat"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "Configureer hotspot"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "Configureer netwerk"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "Configureer DHCP server"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "Configureer OpenVPN"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "Configureer TOR proxy"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "Configureer autenticatie"
 
 msgid "Change Theme"

--- a/locale/pt_BR/LC_MESSAGES/messages.po
+++ b/locale/pt_BR/LC_MESSAGES/messages.po
@@ -31,25 +31,25 @@ msgstr "Portal WiFi RaspAP"
 msgid "Dashboard"
 msgstr "Painel"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "Configurar Cliente WiFi"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "Configurar ponto de acesso"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "Configurar networking"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "Configurar Servidor DHCP"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "Configurar OpenVPN"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "Configurar proxy TOR"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "Configurar Autenticação"
 
 msgid "Change Theme"

--- a/locale/pt_BR/LC_MESSAGES/messages.po
+++ b/locale/pt_BR/LC_MESSAGES/messages.po
@@ -49,7 +49,7 @@ msgstr "Configurar OpenVPN"
 msgid "TOR proxy"
 msgstr "Configurar proxy TOR"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "Configurar Autenticação"
 
 msgid "Change Theme"

--- a/locale/ru_RU/LC_MESSAGES/messages.po
+++ b/locale/ru_RU/LC_MESSAGES/messages.po
@@ -49,7 +49,7 @@ msgstr "Настройка OpenVPN"
 msgid "TOR proxy"
 msgstr "Настройка TOR proxy"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "Настйроки авторизации"
 
 msgid "Change Theme"

--- a/locale/ru_RU/LC_MESSAGES/messages.po
+++ b/locale/ru_RU/LC_MESSAGES/messages.po
@@ -31,25 +31,25 @@ msgstr "Портал RaspAP Wifi"
 msgid "Dashboard"
 msgstr "Приборная панель"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "Настройка WiFi клиента"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "Настройка точки доступа"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "Сетевые настрйоки"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "Настроить DHCP сервер"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "Настройка OpenVPN"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "Настройка TOR proxy"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "Настйроки авторизации"
 
 msgid "Change Theme"

--- a/locale/si_LK/LC_MESSAGES/messages.po
+++ b/locale/si_LK/LC_MESSAGES/messages.po
@@ -49,7 +49,7 @@ msgstr "OpenVPN සැකසුම"
 msgid "TOR proxy"
 msgstr "TOR proxy සැකසුම"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "සත්‍යාපනය වින්‍යාස කරන්න"
 
 msgid "Change Theme"

--- a/locale/si_LK/LC_MESSAGES/messages.po
+++ b/locale/si_LK/LC_MESSAGES/messages.po
@@ -31,25 +31,25 @@ msgstr "RaspAP Wifi වෙබ් අඩවිය"
 msgid "Dashboard"
 msgstr "උපකාරක පුවරුව"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "WiFi සේවාලාභි සැකසුම"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "හොට්ස්පොට් සැකසුම"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "ජාලකරණ සැකසුම"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "DHCP සර්වර් සැකසුම"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "OpenVPN සැකසුම" 
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "TOR proxy සැකසුම"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "සත්‍යාපනය වින්‍යාස කරන්න"
 
 msgid "Change Theme"

--- a/locale/sv_SE/LC_MESSAGES/messages.po
+++ b/locale/sv_SE/LC_MESSAGES/messages.po
@@ -31,25 +31,25 @@ msgstr "RaspAP Wifi Portal"
 msgid "Dashboard"
 msgstr "Dashboard"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "Konfigurera WiFi klienten"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "Konfigurera hotspot"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "Konfigurera nätverk"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "Konfigurera DHCP"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "Konfigurera OpenVPN"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "Konfigurera TOR proxy"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "Konfigurera Auth"
 
 msgid "Change Theme"

--- a/locale/sv_SE/LC_MESSAGES/messages.po
+++ b/locale/sv_SE/LC_MESSAGES/messages.po
@@ -49,7 +49,7 @@ msgstr "Konfigurera OpenVPN"
 msgid "TOR proxy"
 msgstr "Konfigurera TOR proxy"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "Konfigurera Auth"
 
 msgid "Change Theme"

--- a/locale/tr_TR/LC_MESSAGES/messages.po
+++ b/locale/tr_TR/LC_MESSAGES/messages.po
@@ -49,7 +49,7 @@ msgstr "OpenVPN'i yapılandır"
 msgid "TOR proxy"
 msgstr "TOR proxysini yapılandır"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "İzinleri yapılandır"
 
 msgid "Change Theme"

--- a/locale/tr_TR/LC_MESSAGES/messages.po
+++ b/locale/tr_TR/LC_MESSAGES/messages.po
@@ -31,25 +31,25 @@ msgstr "RaspAP Wifi Portalı"
 msgid "Dashboard"
 msgstr "Kontrol Paneli"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "WiFi istemcisini yapılandır"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "Paylaşım noktasını yapılandır"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "Ağı yapılandır"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "DHCP sunucusunu yapılandır"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "OpenVPN'i yapılandır"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "TOR proxysini yapılandır"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "İzinleri yapılandır"
 
 msgid "Change Theme"

--- a/locale/vi_VN/LC_MESSAGES/messages.po
+++ b/locale/vi_VN/LC_MESSAGES/messages.po
@@ -35,25 +35,25 @@ msgstr "Cổng thông tin wifi RaspAP"
 msgid "Dashboard"
 msgstr "Bảng điều khiển"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "Định cấu hình WiFi cho máy khách"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "Định cấu hình điểm phát wifi"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "Đặt cấu hình kết nối mạng"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "Định cấu hình máy chủ DHCP"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "Định cấu hình OpenVPN"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "Định cấu hình proxy TOR"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "Định cấu hình xác thực"
 
 msgid "Change Theme"

--- a/locale/vi_VN/LC_MESSAGES/messages.po
+++ b/locale/vi_VN/LC_MESSAGES/messages.po
@@ -53,7 +53,7 @@ msgstr "Định cấu hình OpenVPN"
 msgid "TOR proxy"
 msgstr "Định cấu hình proxy TOR"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "Định cấu hình xác thực"
 
 msgid "Change Theme"

--- a/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/locale/zh_CN/LC_MESSAGES/messages.po
@@ -49,7 +49,7 @@ msgstr "OpenVPN设置"
 msgid "TOR proxy"
 msgstr "TOR代理设置"
 
-msgid "Auth"
+msgid "Authentication"
 msgstr "登录设置"
 
 msgid "Change Theme"

--- a/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/locale/zh_CN/LC_MESSAGES/messages.po
@@ -31,25 +31,25 @@ msgstr "RaspAP WLAN热点"
 msgid "Dashboard"
 msgstr "仪表板"
 
-msgid "Configure WiFi client"
+msgid "WiFi client"
 msgstr "WLAN客户端设置"
 
-msgid "Configure hotspot"
+msgid "Hotspot"
 msgstr "WLAN热点设置"
 
-msgid "Configure networking"
+msgid "Networking"
 msgstr "网络设置"
 
-msgid "Configure DHCP Server"
+msgid "DHCP Server"
 msgstr "DHCP服务器设置"
 
-msgid "Configure OpenVPN"
+msgid "OpenVPN"
 msgstr "OpenVPN设置"
 
-msgid "Configure TOR proxy"
+msgid "TOR proxy"
 msgstr "TOR代理设置"
 
-msgid "Configure Auth"
+msgid "Auth"
 msgstr "登录设置"
 
 msgid "Change Theme"

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -4,7 +4,7 @@
       <div class="card-header">
         <div class="row">
 	        <div class="col">
-						<i class="fas fa-user-lock mr-2"></i><?php echo _("Configure Auth"); ?>
+						<i class="fas fa-user-lock mr-2"></i><?php echo _("Auth"); ?>
           </div>
         </div><!-- /.row -->
       </div><!-- /.card-header -->

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -4,7 +4,7 @@
       <div class="card-header">
         <div class="row">
 	        <div class="col">
-						<i class="fas fa-user-lock mr-2"></i><?php echo _("Auth"); ?>
+						<i class="fas fa-user-lock mr-2"></i><?php echo _("Authentication"); ?>
           </div>
         </div><!-- /.row -->
       </div><!-- /.card-header -->

--- a/templates/configure_client.php
+++ b/templates/configure_client.php
@@ -4,7 +4,7 @@
       <div class="card-header">
         <div class="row">
           <div class="col">
-            <i class="fas fa-wifi mr-2"></i><?php echo _("Configure WiFi client"); ?>
+            <i class="fas fa-wifi mr-2"></i><?php echo _("WiFi client"); ?>
           </div>
         </div><!-- /.row -->
       </div><!-- /.card-header -->

--- a/templates/dhcp.php
+++ b/templates/dhcp.php
@@ -4,7 +4,7 @@
     <div class="card-header">
       <div class="row">
         <div class="col">
-          <i class="fas fa-exchange-alt mr-2"></i><?php echo _("Configure DHCP"); ?>
+          <i class="fas fa-exchange-alt mr-2"></i><?php echo _("DHCP"); ?>
         </div>
         <div class="col">
           <button class="btn btn-light btn-icon-split btn-sm service-status float-right">

--- a/templates/dhcp.php
+++ b/templates/dhcp.php
@@ -4,7 +4,7 @@
     <div class="card-header">
       <div class="row">
         <div class="col">
-          <i class="fas fa-exchange-alt mr-2"></i><?php echo _("DHCP"); ?>
+          <i class="fas fa-exchange-alt mr-2"></i><?php echo _("DHCP Server"); ?>
         </div>
         <div class="col">
           <button class="btn btn-light btn-icon-split btn-sm service-status float-right">

--- a/templates/hostapd.php
+++ b/templates/hostapd.php
@@ -4,7 +4,7 @@
     <div class="card-header">
       <div class="row">
         <div class="col">
-          <i class="far fa-dot-circle mr-2"></i><?php echo _("Configure hotspot"); ?>
+          <i class="far fa-dot-circle mr-2"></i><?php echo _("Hotspot"); ?>
         </div>
         <div class="col">
           <button class="btn btn-light btn-icon-split btn-sm service-status float-right">

--- a/templates/networking.php
+++ b/templates/networking.php
@@ -4,7 +4,7 @@
     <div class="card-header">
       <div class="row">
         <div class="col">
-          <i class="fas fa-network-wired mr-2"></i><?php echo _("Configure networking"); ?>
+          <i class="fas fa-network-wired mr-2"></i><?php echo _("Networking"); ?>
         </div>
       </div><!-- ./row -->
      </div><!-- ./card-header -->

--- a/templates/openvpn.php
+++ b/templates/openvpn.php
@@ -4,7 +4,7 @@
         <div class="card-header">
           <div class="row">
             <div class="col">
-              <i class="fas fa-key fa-fw mr-2"></i><?php echo _("Configure OpenVPN"); ?>
+              <i class="fas fa-key fa-fw mr-2"></i><?php echo _("OpenVPN"); ?>
             </div>
             <div class="col">
               <button class="btn btn-light btn-icon-split btn-sm service-status float-right">

--- a/templates/torproxy.php
+++ b/templates/torproxy.php
@@ -1,7 +1,7 @@
     <div class="row">
     <div class="col-lg-12">
       <div class="card"> 
-        <div class="card-header"><i class="fa fa-eye-slash fa-fw"></i> Configure TOR proxy</div>
+        <div class="card-header"><i class="fa fa-eye-slash fa-fw"></i> TOR proxy</div>
         <div class="card-body">
             <!-- Nav tabs -->
             <ul class="nav nav-tabs">


### PR DESCRIPTION
i think this is a little cleaner.
couldn't quickly figure out a fast way to recompile all the message file. have an idea but i hate work 🙄 

| before | after |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/201135/75593978-6a604400-5a87-11ea-91e5-450d0cdfdc6b.png) | ![after](https://user-images.githubusercontent.com/201135/75594011-8237c800-5a87-11ea-8b96-8b24f9496260.png) |