### PR TITLE
Add dnsmasq logging options 

### DIFF
--- a/includes/dhcp.php
+++ b/includes/dhcp.php
@@ -65,7 +65,12 @@ function DisplayDHCPConfig()
                 foreach ($_POST['server'] as $server) {
                     $config .= "server=$server".PHP_EOL;
                 }
-
+                if ($_POST['log-dhcp'] == "1") {
+                  $config .= "log-dhcp".PHP_EOL;
+                }
+                if ($_POST['log-queries'] == "1") {
+                  $config .= "log-queries".PHP_EOL;
+                }
                 if ($_POST['DNS1']) {
                     $config .= "dhcp-option=6," . $_POST['DNS1'];
                     if ($_POST['DNS2']) {
@@ -74,6 +79,7 @@ function DisplayDHCPConfig()
                     $config .= PHP_EOL;
                 }
 
+                $config .= "log-facility=/tmp/dnsmasq.log".PHP_EOL;
                 $config .= "conf-dir=/etc/dnsmasq.d".PHP_EOL;
 
                 file_put_contents("/tmp/dnsmasqdata", $config);

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -108,6 +108,13 @@ function create_hostapd_scripts() {
     sudo chmod 750 "$raspap_dir/hostapd/"*.sh || install_error "Unable to change file permissions"
 }
 
+# Generate dnsmasq logfile
+function create_dnsmasq_log() {
+    install_log "Creating dnsmasq logfile"
+    sudo touch /tmp/dnsmasq.log || install_error "Unable to create logfile /tmp/dnsmasq.log"
+    sudo chown dnsmasq:"$raspap_user" /tmp/dnsmasq.log || install_error "Unable to change file ownership"
+}
+
 # Generate lighttpd service control scripts
 function create_lighttpd_scripts() {
     install_log "Creating lighttpd control scripts"
@@ -440,6 +447,7 @@ function install_raspap() {
     download_latest_files
     change_file_ownership
     create_hostapd_scripts
+    create_dnsmasq_log
     create_lighttpd_scripts
     move_config_file
     default_configuration

--- a/templates/dhcp.php
+++ b/templates/dhcp.php
@@ -35,6 +35,7 @@
       <li class="nav-item"><a class="nav-link" href="#advanced" data-toggle="tab"><?php echo _("Advanced"); ?></a></li>
       <li class="nav-item"><a class="nav-link" href="#static-leases" data-toggle="tab"><?php echo _("Static Leases") ?></a></li>
       <li class="nav-item"><a class="nav-link" href="#client-list" data-toggle="tab"><?php echo _("Client list"); ?></a></li>
+      <li class="nav-item"><a class="nav-link" href="#logfile-output" data-toggle="tab"><?php echo _("Logfile output"); ?></a></li>
     </ul>
     <!-- Tab panes -->
     <div class="tab-content">
@@ -96,7 +97,7 @@
       </div>
     </div>
 
-    <?php echo $buttons ?>
+    <?php //echo $buttons ?>
 
     </div><!-- /.tab-pane -->
 
@@ -163,15 +164,29 @@
         </template>
       </div><!-- /.row -->
 
-      <?php echo $buttons ?>
-
+      <div class="row">
+        <div class="col-md-6 mb-3">
+          <h5><?php echo _("Logfile output") ?></h5>
+            <p id="logfile-output-description">
+              <small><?php echo _("Enable these options to log DHCP server activity.") ?></small>
+           </p>
+           <div class="custom-control custom-switch">
+              <input class="custom-control-input" id="log-dhcp" type="checkbox" name="log-dhcp" value="1" <?php echo $conf['log-dhcp'] ? ' checked="checked"' : "" ?> aria-describedby="log-dhcp-requests">
+              <label class="custom-control-label" for="log-dhcp"><?php echo _("Log DHCP requests") ?></label>
+            </div>
+           <div class="custom-control custom-switch">
+             <input class="custom-control-input" id="log-queries" type="checkbox" name="log-queries" value="1" <?php echo $conf['log-queries'] ? ' checked="checked"' : "" ?> aria-describedby="log-dhcp-queries">
+             <label class="custom-control-label" for="log-queries"><?php echo _("Log DNS queries") ?></label>
+           </div>
+        </div>
+      </div><!-- /.row -->
     </div><!-- /.tab-pane | advanded tab -->
 
 		<div class="tab-pane fade" id="client-list">
 		<h4 class="mt-3 mb-3">Client list</h4>
 		<div class="row">
 		<div class="col-lg-12">
-			<div class="card">
+			<div class="card mb-3">
 			<div class="card-header"><?php echo _("Active DHCP leases"); ?></div>
 			<!-- /.panel-heading -->
 			<div class="card-body">
@@ -203,7 +218,10 @@
   </div><!-- /.row -->
   </div><!-- /.tab-pane -->
 
+  <!-- static leases tab -->
   <div class="tab-pane fade" id="static-leases">
+  <h4 class="mt-3 mb-3"><?php echo _("Static leases") ?></h4>
+
     <div class="dhcp-static-leases js-dhcp-static-lease-container">
       <?php foreach ($dhcpHost as $host) : ?>
           <?php list($mac, $ip) = array_map("trim", explode(",", $host)); ?>
@@ -221,7 +239,7 @@
       <?php endforeach ?>
     </div>
 
-    <h4 class="mt-3 mb-3"><?php echo _("Add static DHCP lease") ?></h4>
+    <h5 class="mt-3 mb-3"><?php echo _("Add static DHCP lease") ?></h5>
     <div class="row dhcp-static-lease-row js-new-dhcp-static-lease">
       <div class="col-md-5 col-xs-5">
         <input type="text" name="mac" value="" placeholder="<?php echo _("MAC address") ?>" class="form-control" autofocus="autofocus">
@@ -233,6 +251,7 @@
         <button type="button" class="btn btn-success js-add-dhcp-static-lease"><?php echo _("Add") ?></button>
       </div>
     </div>
+  </div><!-- /.tab-pane -->
 
     <template id="js-dhcp-static-lease-row">
       <div class="row dhcp-static-lease-row js-dhcp-static-lease-row">
@@ -248,7 +267,21 @@
       </div>
     </template>
 
-    <?php echo $buttons ?>
+
+  <!-- logfile output tab -->
+  <div class="tab-pane fade" id="logfile-output">
+    <h4 class="mb-3"><?php echo _("Logfile output"); ?></h4>
+		<div class="row">
+      <div class="form-group col-md-8">
+        <?php
+            $log = file_get_contents('/tmp/dnsmasq.log');
+            echo '<textarea class="logoutput">'.htmlspecialchars($log, ENT_QUOTES).'</textarea>'; 
+        ?>
+      </div><!-- /.col-md-8 -->
+    </div><!-- /.row -->
+  </div><!-- /.tab-pane -->
+
+  <?php echo $buttons ?>
 
   </div>
 

--- a/templates/dhcp.php
+++ b/templates/dhcp.php
@@ -35,7 +35,7 @@
       <li class="nav-item"><a class="nav-link" href="#advanced" data-toggle="tab"><?php echo _("Advanced"); ?></a></li>
       <li class="nav-item"><a class="nav-link" href="#static-leases" data-toggle="tab"><?php echo _("Static Leases") ?></a></li>
       <li class="nav-item"><a class="nav-link" href="#client-list" data-toggle="tab"><?php echo _("Client list"); ?></a></li>
-      <li class="nav-item"><a class="nav-link" href="#logfile-output" data-toggle="tab"><?php echo _("Logfile output"); ?></a></li>
+      <li class="nav-item"><a class="nav-link" href="#logfile-output" data-toggle="tab"><?php echo _("Logging"); ?></a></li>
     </ul>
     <!-- Tab panes -->
     <div class="tab-content">
@@ -97,10 +97,7 @@
       </div>
     </div>
 
-    <?php //echo $buttons ?>
-
     </div><!-- /.tab-pane -->
-
 
     <!-- advanced tab -->
     <div class="tab-pane" id="advanced">
@@ -166,7 +163,7 @@
 
       <div class="row">
         <div class="col-md-6 mb-3">
-          <h5><?php echo _("Logfile output") ?></h5>
+          <h5><?php echo _("Logging") ?></h5>
             <p id="logfile-output-description">
               <small><?php echo _("Enable these options to log DHCP server activity.") ?></small>
            </p>


### PR DESCRIPTION
dnsmasq is fairly opaque without this. I found it useful while testing @glaszig's advanced settings PR. this dumps logfile output to a tab similar to hostapd. 

![image](https://user-images.githubusercontent.com/229399/75973926-43b26b00-5ed6-11ea-944a-c0bdbee31ce5.png)
