### PR TITLE
Workaround for logs permissions not sticking

### DIFF
--- a/installers/common.sh
+++ b/installers/common.sh
@@ -108,13 +108,6 @@ function create_hostapd_scripts() {
     sudo chmod 750 "$raspap_dir/hostapd/"*.sh || install_error "Unable to change file permissions"
 }
 
-# Generate dnsmasq logfile
-function create_dnsmasq_log() {
-    install_log "Creating dnsmasq logfile"
-    sudo touch /tmp/dnsmasq.log || install_error "Unable to create logfile /tmp/dnsmasq.log"
-    sudo chown dnsmasq:"$raspap_user" /tmp/dnsmasq.log || install_error "Unable to change file ownership"
-}
-
 # Generate lighttpd service control scripts
 function create_lighttpd_scripts() {
     install_log "Creating lighttpd control scripts"
@@ -252,8 +245,6 @@ function default_configuration() {
     'echo 1 > \/proc\/sys\/net\/ipv4\/ip_forward #RASPAP'
     'iptables -t nat -A POSTROUTING -j MASQUERADE #RASPAP'
     'iptables -t nat -A POSTROUTING -s 192.168.50.0\/24 ! -d 192.168.50.0\/24 -j MASQUERADE #RASPAP'
-    'chown dnsmasq:www-data \/tmp\/dnsmasq.log #RASPAP'
-    'chown root:www-data \/tmp\/hostapd.log #RASPAP'
     )
     
     for line in "${lines[@]}"; do
@@ -335,6 +326,8 @@ function patch_system_files() {
         "/etc/raspap/hostapd/servicestart.sh"
         "/etc/raspap/lighttpd/configport.sh"
         "/etc/raspap/openvpn/configauth.sh"
+        "/bin/chmod o+r /tmp/hostapd.log"
+        "/bin/chmod o+r /tmp/dnsmasq.log"
     )
 
     # Check if sudoers needs patching
@@ -449,7 +442,6 @@ function install_raspap() {
     download_latest_files
     change_file_ownership
     create_hostapd_scripts
-    create_dnsmasq_log
     create_lighttpd_scripts
     move_config_file
     default_configuration

--- a/installers/enablelog.sh
+++ b/installers/enablelog.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 /bin/sed -i 's|#DAEMON_OPTS=""|DAEMON_OPTS=" -f /tmp/hostapd.log"|' /etc/default/hostapd
 touch /tmp/hostapd.log
-chmod o+r /tmp/hostapd.log

--- a/templates/dhcp/logging.php
+++ b/templates/dhcp/logging.php
@@ -13,6 +13,7 @@
   </div>
 
   <?php
+  exec('sudo chmod o+r /tmp/dnsmasq.log');
   $log = file_get_contents('/tmp/dnsmasq.log');
   echo '<textarea class="logoutput my-3">'.htmlspecialchars($log, ENT_QUOTES).'</textarea>';
   ?>

--- a/templates/hostapd.php
+++ b/templates/hostapd.php
@@ -113,6 +113,7 @@
               <div class="form-group col-md-8">
                 <?php
                 if ($arrHostapdConf['LogEnable'] == 1) {
+                    exec('sudo /bin/chmod o+r /tmp/hostapd.log');
                     $log = file_get_contents('/tmp/hostapd.log');
                     echo '<br /><textarea class="logoutput">'.htmlspecialchars($log, ENT_QUOTES).'</textarea>';
                 } else {


### PR DESCRIPTION
Fix for #525 

`chown` in rc.local triggers an error when the file doesn't exist, thus stopping rc.local execution. To fix, I removed the offending lines in rc.local then made php call `exec()` before it reads the log files, to change the log files permissions.

I also got rid of create_dnsmasq_log as files under `/tmp` are flushed on each reboot anyway.