### PR TITLE
List Connected devices in bridged AP mode

### DIFF
--- a/locale/en_US/LC_MESSAGES/messages.po
+++ b/locale/en_US/LC_MESSAGES/messages.po
@@ -664,8 +664,8 @@ msgid "Attempting to stop TOR"
 msgstr "Attempting to stop TOR"
 
 #: template/dashboard.php
-msgid "<em>Bridged AP mode is enabled. For Hostname and IP, see your router's admin page.</em>"
-msgstr "<em>Bridged AP mode is enabled. For Hostname and IP, see your router's admin page.</em>"
+msgid "Bridged AP mode is enabled. For Hostname and IP, see your router's admin page."
+msgstr "Bridged AP mode is enabled. For Hostname and IP, see your router's admin page."
 
 #: common form controls
 msgid "Save settings"

--- a/locale/en_US/LC_MESSAGES/messages.po
+++ b/locale/en_US/LC_MESSAGES/messages.po
@@ -664,8 +664,8 @@ msgid "Attempting to stop TOR"
 msgstr "Attempting to stop TOR"
 
 #: template/dashboard.php
-msgid "<em>Bridged AP mode is enabled. To find the Hostname and IP of your connected clients, please cross-reference the MAC addresses here with those from your router's admin page.</em>"
-msgstr "<em>Bridged AP mode is enabled. To find the Hostname and IP of your connected clients, please cross-reference the MAC addresses here with those from your router's admin page.</em>"
+msgid "<em>Bridged AP mode is enabled. For Hostname and IP, see your router's admin page.</em>"
+msgstr "<em>Bridged AP mode is enabled. For Hostname and IP, see your router's admin page.</em>"
 
 #: common form controls
 msgid "Save settings"

--- a/locale/en_US/LC_MESSAGES/messages.po
+++ b/locale/en_US/LC_MESSAGES/messages.po
@@ -663,6 +663,10 @@ msgstr "Attempting to start TOR"
 msgid "Attempting to stop TOR"
 msgstr "Attempting to stop TOR"
 
+#: template/dashboard.php
+msgid "<em>Bridged AP mode is enabled. To find the Hostname and IP of your connected clients, please cross-reference the MAC addresses here with those from your router's admin page.</em>"
+msgstr "<em>Bridged AP mode is enabled. To find the Hostname and IP of your connected clients, please cross-reference the MAC addresses here with those from your router's admin page.</em>"
+
 #: common form controls
 msgid "Save settings"
 msgstr "Save settings"

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -11,7 +11,7 @@ if ($arrHostapdConf['BridgedEnable'] == 1) {
   exec('iw dev '.$client_iface.' station dump | grep -oE '.$MACPattern, $clients);
 } else {
   $moreLink = "index.php?page=dhcpd_conf";
-  exec('cat '.RASPI_DNSMASQ_LEASES.'| grep -E $(arp -i '.$client_iface.' -n | grep -oE '.$MACPattern.' | paste -sd "|")', $clients);
+  exec('cat '.RASPI_DNSMASQ_LEASES.'| grep -E $(iw dev '.$client_iface.' station dump | grep -oE '.$MACPattern.' | paste -sd "|")', $clients);
 }
 $ifaceStatus = $wlan0up ? "up" : "down";
 ?>

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -8,7 +8,7 @@ if ($arrHostapdConf['WifiAPEnable'] == 1) {
 $MACPattern = '"([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}"';
 if ($arrHostapdConf['BridgedEnable'] == 1) {
   $moreLink = "index.php?page=hostapd_conf";
-  exec('arp -i '.$client_iface.' -a | grep -E $(iw dev '.$client_iface.' station dump | grep -oE '.$MACPattern.' | paste -sd "|") | tr -d "()" | awk -F" " \'{print $7 " " $4 " " $2 " " $1}\'', $clients);
+  exec('iw dev '.$client_iface.' station dump | grep -oE '.$MACPattern, $clients);
 } else {
   $moreLink = "index.php?page=dhcpd_conf";
   exec('cat '.RASPI_DNSMASQ_LEASES.'| grep -E $(arp -i '.$client_iface.' -n | grep -oE '.$MACPattern.' | paste -sd "|")', $clients);
@@ -78,18 +78,31 @@ $ifaceStatus = $wlan0up ? "up" : "down";
                   <table class="table table-hover">
                     <thead>
                       <tr>
-                        <th><?php echo _("Host name"); ?></th>
-                        <th><?php echo _("IP Address"); ?></th>
-                        <th><?php echo _("MAC Address"); ?></th>
+                        <?php if ($arrHostapdConf['BridgedEnable'] == 1) : ?>
+                          <th><?php echo _("MAC Address"); ?></th>
+                        <?php else : ?>
+                          <th><?php echo _("Host name"); ?></th>
+                          <th><?php echo _("IP Address"); ?></th>
+                          <th><?php echo _("MAC Address"); ?></th>
+                        <?php endif; ?>
                       </tr>
                     </thead>
                     <tbody>
+                        <?php if ($arrHostapdConf['BridgedEnable'] == 1) : ?>
+                          <tr>
+                            <td><?php echo _("<em>Bridged AP mode is enabled. To find the Hostname and IP of your connected clients, please cross-reference the MAC addresses here with those from your router's admin page.</em>");?></td>
+                          </tr>
+                        <?php endif; ?>
                         <?php foreach (array_slice($clients,0, 2) as $client) : ?>
-                            <?php $props = explode(' ', $client) ?>
                         <tr>
-                          <td><?php echo htmlspecialchars($props[3], ENT_QUOTES) ?></td>
-                          <td><?php echo htmlspecialchars($props[2], ENT_QUOTES) ?></td>
-                          <td><?php echo htmlspecialchars($props[1], ENT_QUOTES) ?></td>
+                          <?php if ($arrHostapdConf['BridgedEnable'] == 1): ?>
+                            <td><?php echo htmlspecialchars($client, ENT_QUOTES) ?></td>
+                          <?php else : ?>
+                            <?php $props = explode(' ', $client) ?>
+                            <td><?php echo htmlspecialchars($props[3], ENT_QUOTES) ?></td>
+                            <td><?php echo htmlspecialchars($props[2], ENT_QUOTES) ?></td>
+                            <td><?php echo htmlspecialchars($props[1], ENT_QUOTES) ?></td>
+                          <?php endif; ?>
                         </tr>
                         <?php endforeach ?>
                     </tbody>

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -90,7 +90,7 @@ $ifaceStatus = $wlan0up ? "up" : "down";
                     <tbody>
                         <?php if ($arrHostapdConf['BridgedEnable'] == 1) : ?>
                           <tr>
-                            <td><?php echo _("<em>Bridged AP mode is enabled. To find the Hostname and IP of your connected clients, please cross-reference the MAC addresses here with those from your router's admin page.</em>");?></td>
+                            <td><?php echo _("<em>Bridged AP mode is enabled. For Hostname and IP, see your router's admin page.</em>");?></td>
                           </tr>
                         <?php endif; ?>
                         <?php foreach (array_slice($clients,0, 2) as $client) : ?>

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -5,7 +5,7 @@ if ($arrHostapdConf['WifiAPEnable'] == 1) {
 } else {
   $client_iface = RASPI_WIFI_CLIENT_INTERFACE;
 }
-$MACPattern = '([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}';
+$MACPattern = '"([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}"';
 if ($arrHostapdConf['BridgedEnable'] == 1) {
   $moreLink = "index.php?page=hostapd_conf";
   exec('arp -i '.$client_iface.' -a | grep -E $(iw dev '.$client_iface.' station dump | grep -oE '.$MACPattern.' | paste -sd "|") | tr -d "()" | awk -F" " \'{print $7 " " $4 " " $2 " " $1}\'', $clients);

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -90,7 +90,7 @@ $ifaceStatus = $wlan0up ? "up" : "down";
                     <tbody>
                         <?php if ($arrHostapdConf['BridgedEnable'] == 1) : ?>
                           <tr>
-                            <td><?php echo _("<em>Bridged AP mode is enabled. For Hostname and IP, see your router's admin page.</em>");?></td>
+                            <td><small class="text-muted"><?php echo _("Bridged AP mode is enabled. For Hostname and IP, see your router's admin page.");?></small></td>
                           </tr>
                         <?php endif; ?>
                         <?php foreach (array_slice($clients,0, 2) as $client) : ?>


### PR DESCRIPTION
For #538 

Because the upstream router takes care of DHCP requests in bridged mode, `arp` doesn't cache any entries. We use `iw dev wlan0 station dump` to at least find the MAC addresses of devices connected to wlan0.

A hacky way to find the IP addresses of these connected devices is to do an IP scan of the LAN with `nmap`. Any pinged device from this scan will have its data cached by arp (EXCEPT for the hostname!!). However, this adds another dependency to RaspAP.

## What I've Done
- `$clients` in bridged mode is a list of connected devices MAC addrs
- `$clients` in default mode still functions the same, but I simplified the exec() internals
- info text appears in bridged mode: tells users to see their own router page for more info
- "More" link directs to hostapd page rather than dhcp for bridged mode.

## How to proceed
1. Should I use nmap to at least get IP of connected devices in bridged mode?
2. In default routed mode, should Connected Devices use iw station dump to further filter out unconnected devices that still have a dnsmasq lease?