### PR TITLE
Use php-parallel-lint/php-parallel-lint instead of jakub-onderka/php-parallel-lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "GPL-3.0",
     "keywords": ["raspberrypi"],
     "require-dev": {
-        "jakub-onderka/php-parallel-lint": "1.0.0",
+        "php-parallel-lint/php-parallel-lint": "^1.2.0",
         "phpcompatibility/php-compatibility": "^9.3.5",
         "squizlabs/php_codesniffer": "^3.5.5"
     },


### PR DESCRIPTION
Should've done this in https://github.com/billz/raspap-webgui/pull/568 but not sure why I didn't

`jakub-onderka` packages are abandoned, so the new org is the currently maintained ones