### PR TITLE
Sort and filter available client networks

### DIFF
--- a/ajax/networking/wifi_stations.php
+++ b/ajax/networking/wifi_stations.php
@@ -13,5 +13,6 @@ $ssid     = null;
 knownWifiStations($networks);
 nearbyWifiStations($networks, !isset($_REQUEST["refresh"]));
 connectedWifiStations($networks);
+sortNetworksByRSSI($networks);
 
 echo renderTemplate('wifi_stations', compact('networks'));

--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -94,6 +94,7 @@ function DisplayWPAConfig()
 
     nearbyWifiStations($networks);
     connectedWifiStations($networks);
+    sortNetworksByRSSI($networks);
 
     echo renderTemplate("configure_client", compact("status"));
 }

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -133,13 +133,9 @@ function DisplayDashboard(&$extraFooterScripts)
     // Display link quality as signal quality for now.
     $strLinkQuality = 0;
     if ($signalLevel > -100 && $wlanHasLink) {
-        if ($signalLevel >= 0) {
-            $strLinkQuality = 100;
-        } else {
-            $strLinkQuality = 100 + $signalLevel;
-        }
+        if ($signalLevel >= -50)        $strLinkQuality = 100;
+        else                            $strLinkQuality =  2*($signalLevel + 100);
     }
-
     $wlan0up = false;
     $classMsgDevicestatus = 'warning';
     if ($interfaceState === 'UP') {

--- a/includes/wifi_functions.php
+++ b/includes/wifi_functions.php
@@ -63,16 +63,26 @@ function nearbyWifiStations(&$networks, $cached = true)
         }
     );
 
-    foreach (explode("\n", $scan_results) as $network) {
-        $arrNetwork = preg_split("/[\t]+/", $network);  // split result into array
+    // get the name of the AP - should be excluded von the nearby networks
+	$pars=parse_ini_file(RASPI_HOSTAPD_CONFIG,false,INI_SCANNER_RAW );
+	$ap_ssid = $pars['ssid'];
+	
+	foreach (explode("\n", $scan_results) as $network) {
+		$arrNetwork = preg_split("/[\t]+/", $network);  // split result into array
+        if (!array_key_exists(4, $arrNetwork) ||
+            trim($arrNetwork[4]) == $ap_ssid) continue;
+
+        $ssid = trim($arrNetwork[4]);
+        // filter SSID string - anything invisable in 7bit ASCII or quotes -> ignore network
+        if( preg_match('/[\x00-\x1f\x7f-\xff\'\`\´\"]/',$ssid)) continue;
 
         // If network is saved
-        if (array_key_exists(4, $arrNetwork) && array_key_exists($arrNetwork[4], $networks)) {
-            $networks[$arrNetwork[4]]['visible'] = true;
-            $networks[$arrNetwork[4]]['channel'] = ConvertToChannel($arrNetwork[1]);
+        if (array_key_exists($ssid, $networks)) {
+            $networks[$ssid]['visible'] = true;
+            $networks[$ssid]['channel'] = ConvertToChannel($arrNetwork[1]);
             // TODO What if the security has changed?
         } else {
-            $networks[$arrNetwork[4]] = array(
+            $networks[$ssid] = array(
                 'configured' => false,
                 'protocol' => ConvertToSecurity($arrNetwork[3]),
                 'channel' => ConvertToChannel($arrNetwork[1]),
@@ -82,10 +92,12 @@ function nearbyWifiStations(&$networks, $cached = true)
             );
         }
 
-        // Save RSSI
-        if (array_key_exists(4, $arrNetwork)) {
-            $networks[$arrNetwork[4]]['RSSI'] = $arrNetwork[2];
+        // Save RSSI, if the current value is larger than the already stored
+        if (array_key_exists(4, $arrNetwork) && array_key_exists($arrNetwork[4],$networks)) {
+            if(! array_key_exists('RSSI',$networks[$arrNetwork[4]]) || $networks[$ssid]['RSSI'] < $arrNetwork[2])
+                $networks[$ssid]['RSSI'] = $arrNetwork[2];
         }
+
     }
 }
 
@@ -97,4 +109,19 @@ function connectedWifiStations(&$networks)
             $networks[$iwconfig_ssid[1]]['connected'] = true;
         }
     }
+}
+
+function sortNetworksByRSSI(&$networks) {
+        $valRSSI = array();
+        foreach ($networks as $SSID => $net) {
+                if (!array_key_exists('RSSI',$net)) $net['RSSI'] = -1000;
+                $valRSSI[$SSID] = $net['RSSI'];
+        }
+        $nets = $networks;
+        arsort($valRSSI);
+        $networks = array();
+        foreach ($valRSSI as $SSID => $RSSI) {
+                $networks[$SSID] = $nets[$SSID];
+                $networks[$SSID]['RSSI'] = $RSSI;
+        }
 }

--- a/templates/wifi_stations.php
+++ b/templates/wifi_stations.php
@@ -40,16 +40,15 @@
 
 	<div class="info-item-wifi"><?php echo _("RSSI"); ?></div>
         <div>
-	  <?php echo htmlspecialchars($network['RSSI'], ENT_QUOTES);
-	      echo "dB (";
-	  if ($network['RSSI'] >= -50) {
-	      echo 100;
-	  } elseif ($network['RSSI'] <= -100) {
-	      echo 0;
-	  } else {
-	      echo  2*($network['RSSI'] + 100);
-	  }
-	      echo "%)";
+	  <?php 
+		if (isset($network['RSSI']) && $network['RSSI'] >= -200 ) {
+			echo htmlspecialchars($network['RSSI'], ENT_QUOTES);
+			echo "dB (";
+            if ($network['RSSI'] >= -50) echo 100;
+            elseif ($network['RSSI'] <= -100) echo 0;
+            else echo  2*($network['RSSI'] + 100);
+            echo "%)";
+        } else echo " not found ";
 	  ?>
         </div>
 


### PR DESCRIPTION
Hi Billz,
here the pull request for sorting the networks for the Wifi client:
- sorted by signal strength
- known networks, which are not found are listed at the end
- all SSIDs are filtered for invisible characters

In addition I straightened out the inconsistent signal quality on the dashboard. It should be now the same as the value displayed for the client networks.

Cheers
  Christian