### PR TITLE
Change the QR Code image path

### DIFF
--- a/templates/hostapd/security.php
+++ b/templates/hostapd/security.php
@@ -20,7 +20,7 @@
     </div>
     <div class="col-md-6">
       <figure class="figure">
-        <img src="/app/img/wifi-qr-code.php" class="figure-img img-fluid" alt="RaspAP Wifi QR code" style="width:100%;">
+        <img src="app/img/wifi-qr-code.php" class="figure-img img-fluid" alt="RaspAP Wifi QR code" style="width:100%;">
         <figcaption class="figure-caption"><?php echo _("Scan this QR code with your phone to connect to this RaspAP."); ?></figcaption>
       </figure>
     </div>


### PR DESCRIPTION
The QR image path doesn't work on non standard install locations, i.e. "/var/www/html/wifi/". Changing it to a relative path seems to fix the issue.