### PR TITLE
Remove prompt from apt

### DIFF
--- a/installers/common.sh
+++ b/installers/common.sh
@@ -266,7 +266,7 @@ function _prompt_install_openvpn() {
 function _install_openvpn() {
     _install_log "Installing OpenVPN and enabling client configuration"
     echo "Adding packages via apt-get"
-    sudo apt-get install $apt_option openvpn || _install_status 1 "Unable to install openvpn"
+    sudo apt-get install -y $apt_option openvpn || _install_status 1 "Unable to install openvpn"
     sudo sed -i "s/\('RASPI_OPENVPN_ENABLED', \)false/\1true/g" "$webroot_dir/includes/config.php" || _install_status 1 "Unable to modify config.php"
     echo "Enabling openvpn-client service on boot"
     sudo systemctl enable openvpn-client@client || _install_status 1 "Unable to enable openvpn-client daemon"


### PR DESCRIPTION
Add `-y` flag to apt so it doesn't show a prompt, which then causes errors during the install.

Should fix #690, which I'm pretty sure shouldn't have been closed. :)