### PR TITLE
Fixed function getWifiInterface for rpi0W in AP-STA mode.

### DIFF
--- a/includes/hostapd.php
+++ b/includes/hostapd.php
@@ -130,6 +130,8 @@ function SaveHostAPDConfig($wpa_array, $enc_types, $modes, $interfaces, $status)
         $status->addMessage('Attempting to set channel outside of permitted range', 'danger');
         $good_input = false;
     }
+    
+    $arrHostapdConf = parse_ini_file('/etc/raspap/hostapd.ini');
   
     // Check for Bridged AP mode checkbox
     $bridgedEnable = 0;

--- a/includes/wifi_functions.php
+++ b/includes/wifi_functions.php
@@ -146,12 +146,12 @@ function getWifiInterface()
         $iface = $_SESSION['ap_interface'] = isset($arrHostapdConf['WifiInterface']) ?  $arrHostapdConf['WifiInterface'] : RASPI_WIFI_AP_INTERFACE;
         // check for 2nd wifi interface -> wifi client on different interface
         exec("iw dev | awk '$1==\"Interface\" && $2!=\"$iface\" {print $2}'",$iface2);
-        $client_iface = $_SESSION['wifi_client_interface'] = empty($iface2) ? $iface : trim($iface2[0]);
+        $client_iface = $_SESSION['wifi_client_interface'] = (empty($iface2) ? $iface : trim($iface2[0]));
 
         // specifically for rpi0W in AP-STA mode, the above check ends up with the interfaces
         // crossed over (wifi_client_interface vs 'ap_interface'), because the second interface (uap0) is 
         // created by raspap and used as the access point.
-        if ($iface == "wlan0" && $client_iface = "uap0"  && ($arrHostapdConf['WifiAPEnable'] ?? 0)){
+        if ($client_iface == "uap0"  && ($arrHostapdConf['WifiAPEnable'] ?? 0)){
             $_SESSION['wifi_client_interface'] = $iface;
             $_SESSION['ap_interface'] = $client_iface; 
         } 

--- a/includes/wifi_functions.php
+++ b/includes/wifi_functions.php
@@ -53,7 +53,7 @@ function nearbyWifiStations(&$networks, $cached = true)
 
     $scan_results = cache(
         $cacheKey, function () {
-            exec('sudo wpa_cli -i ' .$_SESSION['wifi_client_interface']. ' scan', $output, $returnval);
+            exec('sudo wpa_cli -i ' .$_SESSION['wifi_client_interface']. ' scan');
             sleep(3);
 
             exec('sudo wpa_cli -i ' .$_SESSION['wifi_client_interface']. ' scan_results', $stdout);

--- a/templates/configure_client.php
+++ b/templates/configure_client.php
@@ -1,10 +1,7 @@
 <?php
-$arrHostapdConf = parse_ini_file(RASPI_CONFIG.'/hostapd.ini');
-if ($arrHostapdConf['WifiAPEnable'] == 1) {
-    $client_interface = 'uap0';
-} else {
-    $client_interface = $_SESSION['wifi_client_interface'];
-}
+
+$client_interface = $_SESSION['wifi_client_interface'];
+
 exec('ip a show '.$client_interface, $stdoutIp);
 $stdoutIpAllLinesGlued = implode(" ", $stdoutIp);
 $stdoutIpWRepeatedSpaces = preg_replace('/\s\s+/', ' ', $stdoutIpAllLinesGlued);

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -1,10 +1,8 @@
 <?php
 $arrHostapdConf = parse_ini_file(RASPI_CONFIG.'/hostapd.ini');
-if ($arrHostapdConf['WifiAPEnable'] == 1) {
-    $client_interface = 'uap0';
-} else {
-    $client_interface = $_SESSION['wifi_client_interface'];
-}
+
+$client_interface = $_SESSION['wifi_client_interface'];
+
 $ap_iface = $_SESSION['ap_interface'];
 $MACPattern = '"([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}"';
 if ($arrHostapdConf['BridgedEnable'] == 1) {


### PR DESCRIPTION
The old version would get 'wifi_client_interface' and 'ap_interface' reversed when rpi0W is used in AP-STA mode.  It meant that once AP-STA mode is set up, the GUI could not properly scan for networks, and change many settings.  This PR fixes the issue.

I found the problem because I am currently trying to use this project in an IOT device which contains an rpi0W.  It took all day and then some to get the system working.  I am not sure how AP-STA mode could have ever worked with the webgui, so someone with some idea of project history might want to comment on the issue.